### PR TITLE
Add project lifecycle

### DIFF
--- a/tac/governing-documents/MAINTAINERS-file.md
+++ b/tac/governing-documents/MAINTAINERS-file.md
@@ -1,0 +1,120 @@
+---
+layout: default
+title: MAINTAINERS Guidelines
+parent: Governing Documents
+grand_parent: LF Decentralized Trust TAC
+nav_order: 2
+---
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+## Introduction
+
+All LF Decentralized Trust (LFDT) repositories **MUST** have a `MAINTAINERS.md` file at the top-level directory of the source code. The [SAMPLE-MAINTAINERS.md](./SAMPLE-MAINTAINERS) can be used as a template by projects creating a new repository.
+
+The Technical Steering Committee (TSC) for the project to which a repository belongs **MUST** periodically send out notifications about missing `MAINTAINERS.md` files.
+
+The LFDT GitHub organization administrators (i.e., LFDT TAC) **SHOULD** periodically send out notifications about missing `MAINTAINERS.md` files.
+
+The following provides guidelines and suggested content to include in the `MAINTAINERS.md` file.
+
+## Maintainer Scopes and GitHub Roles
+
+Becoming a Maintainer for a repository implies being granted special privileges
+within that repository to do the additional scope(s) of work required of a
+Maintainer. In most cases, the additional privileges are implemented by giving
+maintainers one of the elevated [GitHub
+roles](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/repository-roles-for-an-organization)
+within the repository.
+
+In most repositories, the "Maintainer" scope is given to all repository
+Maintainers. The "Maintainer" scope is defined as the "Maintain" GitHub role.
+This is usually sufficient to do all of the work required of a Maintainer. From
+time to time, Maintainers may have to request certain administrative tasks by
+performed by the LFDT GitHub organization administrators.
+
+In some repositories, the maintainers may decide to define additional scopes and
+each Maintainer given one or more of those designated scopes:
+
+- In rare cases, Maintainers in a repository may request that the project's TSC enable designating some Maintainers with different GitHub roles, such as "Admin" (more capable than "Maintain") or "Triage" (less capable than "Maintain").
+  - Each elevated GitHub role needed in a repository requires the project's TSC to create and maintain an additional GitHub Team.
+  - The LFDT TAC manages a team per LFDT Project that includes all contributors to the project. That team is given the "Read" GitHub role in all project repositories. This team need not be documented in the "MAINTAINERS" file.
+- Maintainers **MAY** define Maintainer scopes within a repository that don't require
+  elevated GitHub privileges. For example, a scope might include hosting
+  community meetings, or contributing to the LFDT Project's Quarterly
+  report.
+
+If there is more than the single "Maintainer" scope used in a repository, there **MUST** be a list of the repository specific scopes in the MAINTAINERS file. The list must include the scope name, the definition of the scope, and if applicable, the related GitHub Role and Team for the scope.
+
+| Scope      | Definition               | GitHub Role | GitHub Team               |
+| ---------- | ------------------------ | ----------- | ------------------------- |
+| Maintainer | The GitHub Maintain role | Maintain    | `<repository> committers` |
+
+## List of Repository Maintainers
+
+Lists of active and emeritus maintainers **MUST** be included in the `MAINTAINERS.md` file.
+
+Changes to the maintainers lists **MUST** be made via Pull Requests. Once a new `MAINTAINERS.md` file is created or a PR changing the maintainer lists within the file is merged, a corresponding update to the affected GitHub Teams within the LFDT GitHub organization must be made. This is a manual process and the maintainers must ensure that it occurs.
+
+It is recommended that the lists be sorted alphabetically and **MUST** contain at least the Maintainers name, GitHub ID, Scope, and at least one contact method. The reasons for populating columns are:
+
+- A GitHub ID **MUST** be provided to add the Maintainer to a GitHub Team, and to recognize the action the Maintainer takes in the repository.
+- The Scope **MUST** be provided to know the role of each Maintainer, and to know the GitHub Team to update when adding/removing Maintainers.
+- A LFID (Linux Foundation ID), Discord ID and/or Email are the most effective ways for the LFDT to contact the Maintainer when necessary.
+- A Company Affiliation is helpful for monitoring the diversity of the Maintainer community for a project.
+
+The following table format **MUST** be used for both Maintainers lists (active and emeritus):
+
+**Active Maintainers**
+
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+| ---- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
+|      |           |       |      |            |       |                     |
+
+**Emeritus Maintainers**
+
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+| ---- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
+|      |           |       |      |            |       |                     |
+
+## Maintainer Duties
+
+The `MAINTAINERS.md` file **SHOULD** contain information about the different
+maintainer scopes, and for each, the maintainers duties (e.g., maintainers
+calls, quarterly reports, code reviews, issue cleansing). See the [Sample
+Maintainers](./SAMPLE-MAINTAINERS) for an example of what to include in this
+section for an open source software project. Feel free to evolve that text to
+match the needs of the repository and project.
+
+If the repository is for a community specification, or other governance or
+documentation purpose, the tasks of the Maintainers (often called "Editors"
+in such cases) might be different than for Maintainers of an open source code
+project. The Maintainer role is more about approving and merging pull requests
+that reflect the agreement of the community, as opposed to code related metrics
+(quality, fit for purpose, tests, etc.). In some cases, a GOVERNANCE.md file
+like the [AnonCreds Methods Registry governance file] might further define the duties of the maintainers.
+
+[AnonCreds Methods Registry governance file]: https://github.com/hyperledger/anoncreds-methods-registry/blob/main/registry/governance.md
+
+## How to Become a Maintainer
+
+The `MAINTAINERS.md` file **SHOULD** contain information about how to become a
+maintainer for the project. This section **SHOULD** list specific information
+about what is required. Information that **SHOULD** be included in this section:
+
+* What is required before someone can be considered to become a maintainer.
+  * Include a statement on how an emeritus maintainer can be changed to active again.
+* Consider whether there should be different requirements based on the scope of a given maintainer.
+* Whether sponsorship by an existing maintainer is required.
+* How maintainers are proposed to the community. Proposals are typically done by creating PR against the `MAINTAINERS.md` file, and including information in the PR about how the proposed contributor meets the criteria to be a maintainer.
+* How many maintainers must approve the proposed maintainer.
+* How long the existing maintainers have to respond to the proposal.
+
+## How Maintainers are Removed or Moved to Emeritus Status
+
+The `MAINTAINERS.md` file **SHOULD** contain information about how a maintainer is removed from the list of active maintainers. Information that **SHOULD** be included in this section:
+
+* The reasons a maintainer would be removed from the list of active maintainers.
+* How a removal is proposed. Typically, this is similar to the way in which maintainers are added, such as via a PR against the `MAINTAINERS.md` file.
+
+# References
+* [TAC Decision Log - Common Maintainers Management Policy](https://wiki.hyperledger.org/display/TSC/Common+Maintainers+management+policy)

--- a/tac/governing-documents/SAMPLE-MAINTAINERS.md
+++ b/tac/governing-documents/SAMPLE-MAINTAINERS.md
@@ -1,0 +1,117 @@
+---
+layout: default
+title: Sample MAINTAINERS file
+nav_exclude: true
+---
+[//]: # remove this line, and all prior, before using in a repo.
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+# Maintainers
+
+This is a sample `MAINTAINERS.md` file for a LF Decentralized Trust (LFDT) project repository.
+Feel free to copy this file into your repository and update it for your specific
+needs.
+
+It is sufficient to have a `MAINTAINERS.md` file that contains only a reference to a `MAINTAINERS.md` file in another repository that is part of the LFDT project.  For example:
+
+> For information about the Maintainers of this repository, please see this \<PROJECT> repository's [MAINTAINERS](#) file.
+
+## Maintainer Scopes, GitHub Roles and GitHub Teams
+
+Maintainers are assigned the following scopes in this repository:
+
+| Scope | Definition | GitHub Role | GitHub Team |
+| ----- | ---------- | ----------- | ----------- |
+| Maintainer | The GitHub Maintain role | Maintain   | `<repository> committers`     |
+
+## Active Maintainers
+
+<!-- Please keep this sorted alphabetically by github -->
+
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+|----- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
+|      |           |       |      |            |       |                     |
+
+
+## Emeritus Maintainers
+
+| Name | GitHub ID | Scope | LFID | Discord ID | Email | Company Affiliation |
+|----- | --------- | ----- | ---- | ---------- | ----- | ------------------- |
+|      |           |       |      |            |       |                     |
+
+## The Duties of a Maintainer
+
+Maintainers are expected to perform the following duties for this repository. The duties are listed in more or less priority order:
+
+- Review, respond, and act on any security vulnerabilities reported against the repository.
+- Review, provide feedback on, and merge or reject GitHub Pull Requests from
+  Contributors.
+- Review, triage, comment on, and close GitHub Issues
+  submitted by Contributors.
+- When appropriate, lead/facilitate architectural discussions in the community.
+- When appropriate, lead/facilitate the creation of a product roadmap.
+- Create, clarify, and label issues to be worked on by Contributors.
+- Ensure that there is a well defined (and ideally automated) product test and
+  release pipeline, including the publication of release artifacts.
+- When appropriate, execute the product release process.
+- Maintain the repository CONTRIBUTING.md file and getting started documents to
+  give guidance and encouragement to those wanting to contribute to the product, and those wanting to become maintainers.
+- Contribute to the product via GitHub Pull Requests.
+- Monitor requests from the LF Decentralized Trust Technical Advisory Council about the
+contents and management of LFDT repositories, such as branch handling,
+required files in repositories and so on.
+- Contribute to the LFDT Project's Quarterly Report.
+
+## Becoming a Maintainer
+
+This community welcomes contributions. Interested contributors are encouraged to
+progress to become maintainers. To become a maintainer the following steps
+occur, roughly in order.
+
+- The proposed maintainer establishes their reputation in the community,
+  including authoring five (5) significant merged pull requests, and expresses
+  an interest in becoming a maintainer for the repository.
+- A PR is created to update this file to add the proposed maintainer to the list of active maintainers.
+- The PR is authored by an existing maintainer or has a comment on the PR from an existing maintainer supporting the proposal.
+- The PR is authored by the proposed maintainer or has a comment on the PR from the proposed maintainer confirming their interest in being a maintainer.
+  - The PR or comment from the proposed maintainer must include their
+    willingness to be a long-term (more than 6 month) maintainer.
+- Once the PR and necessary comments have been received, an approval timeframe begins.
+- The PR **MUST** be communicated on all appropriate communication channels, including relevant community calls, chat channels and mailing lists. Comments of support from the community are welcome.
+- The PR is merged and the proposed maintainer becomes a maintainer if either:
+  - Two weeks have passed since at least three (3) Maintainer PR approvals have been recorded, OR
+  - An absolute majority of maintainers have approved the PR.
+- If the PR does not get the requisite PR approvals, it may be closed.
+- Once the add maintainer PR has been merged, any necessary updates to the GitHub Teams are made.
+
+## Removing Maintainers
+
+Being a maintainer is not a status symbol or a title to be carried
+indefinitely. It will occasionally be necessary and appropriate to move a
+maintainer to emeritus status. This can occur in the following situations:
+
+- Resignation of a maintainer.
+- Violation of the Code of Conduct warranting removal.
+- Inactivity.
+  - A general measure of inactivity will be no commits or code review comments
+    for one reporting quarter. This will not be strictly enforced if
+    the maintainer expresses a reasonable intent to continue contributing.
+  - Reasonable exceptions to inactivity will be granted for known long term
+    leave such as parental leave and medical leave.
+- Other circumstances at the discretion of the other Maintainers.
+
+The process to move a maintainer from active to emeritus status is comparable to the process for adding a maintainer, outlined above. In the case of voluntary
+resignation, the Pull Request can be merged following a maintainer PR approval. If the removal is for any other reason, the following steps **SHOULD** be followed:
+
+- A PR is created to update this file to move the maintainer to the list of emeritus maintainers.
+- The PR is authored by, or has a comment supporting the proposal from, an existing maintainer or a member of the project's Technical Steering Commitee (TSC).
+- Once the PR and necessary comments have been received, the approval timeframe begins.
+- The PR **MAY** be communicated on appropriate communication channels, including relevant community calls, chat channels and mailing lists.
+- The PR is merged and the maintainer transitions to maintainer emeritus if:
+  - The PR is approved by the maintainer to be transitioned, OR
+  - Two weeks have passed since at least three (3) Maintainer PR approvals have been recorded, OR
+  - An absolute majority of maintainers have approved the PR.
+- If the PR does not get the requisite PR approvals, it may be closed.
+
+Returning to active status from emeritus status uses the same steps as adding a
+new maintainer. Note that the emeritus maintainer already has the 5 required
+significant changes as there is no contribution time horizon for those.

--- a/tac/governing-documents/project-incubation-exit.md
+++ b/tac/governing-documents/project-incubation-exit.md
@@ -1,0 +1,158 @@
+---
+layout: default
+title: Project Incubation Exit Criteria
+parent: Governing Documents
+grand_parent: LF Decentralized Trust TAC
+nav_order: 6
+---
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# Project Incubation Exit Criteria
+
+## Introduction
+
+LF Decentralized Trust has defined a [lifecycle](./project-lifecycle) for its
+projects but this definition does not specify in any detail what it
+takes for a project to be able to transition from the
+*Incubation* phase to the *Graduated* phase.
+
+This document is meant to fill this gap by defining a set of criteria to
+be considered before moving a project from *Incubation*
+to *Graduated*.
+
+It is important to note that *Graduated* in this case refers to
+the project itself rather than its product and it is therefore more
+about the maturity of process than the maturity of the product or
+General Availability (GA).
+
+For this reason this document defines two sets of exit criteria. The
+first one is made of requirements expected to be met by all projects
+before moving to *Graduated*. The second set lists examples of
+additional requirements typically defined at the onset of the project as
+goals to be met to exit *Incubation*. These are expected to be documented
+in a [Project Proposal](https://lf-decentralized-trust.github.io/project-proposals/)
+Because not all projects have the same goals, the importance of each
+criteria and the exact definition of this second set of criteria may
+vary from one project to another. Ultimately the TAC is responsible for
+determining whether a project deserves to move to *Graduated* or
+not and this decision does not need to be solely based on these exit
+criteria. The purpose of these exit criteria is to help the TAC in its
+decision process by informing its members of key aspects of the project.
+
+# Minimum requirements
+
+-   Legal
+
+    -   All code has been made available under the Apache License and is
+        free of incompatible dependencies
+    -   Project name has been checked for trademark issues
+
+-   Community support
+
+    -   The project must have an active and diverse set of contributing
+        members representing various constituencies
+    -   The project is not highly dependent on any single contributor
+        (there are at least 3 legally independent committers and there
+        is no single company or entity that is vital to the success of
+        the project)
+    -   Release plans are developed and executed in public by the
+        community.
+
+-   Sufficient test coverage
+
+    The project must include a comprehensive unit and integration test
+    suite and document its coverage. Additional performance and scale
+    test capability is desirable.
+
+-   Sufficient user documentation
+
+    The project must including enough documentation for anyone to test
+    or deploy any of the modules.
+
+-   Alignment
+
+    -   Requirements fulfillment
+
+        The project must document what requirements and use cases it addresses.
+
+    -   Compatibility with other LF Decentralized Trust projects
+
+        Where applicable, the project should be compatible with other
+        *Graduated* projects.
+
+    -   Release numbering: the project should use the LF Decentralized Trust
+        standard [release taxonomy](./release-taxonomy), once that is agreed upon.
+
+    -   Project must make a [release](./release-taxonomy), even a "developer preview",
+        before graduation.
+
+-   Infrastructure
+
+    -   Github repo has been created
+    -   Mailing lists have been created and are archived
+    -   Other communication means used, such as chat channels, are set up
+    -   Project is set up with Continuous Integration
+    -   All project repos have implemented the [common repository structure](./repository-structure)
+
+-   Security
+
+    The project must identify key contact points to address
+    security related questions and concerns.
+    Some of the other responsibilities for them include:
+
+    -   Address automated alerts, such as depend-a-bot, in a timely manner.
+
+    -   Participate in LF Decentralized Trust wide security discussions.
+
+-   OpenSSF Best Practices Badge
+
+    A project seeking to graduate from *Incubation* shall have started the
+    OpenSSF Best Practices Badge application and be nearly complete with
+    incomplete badge requirements referenced in their graduation proposal.
+    That does not mean the project must have 100% of all criteria, just
+    100% of the applicable criteria. This is to allow for projects such
+    as test harnesses, that have "N/A" answers for questions that don\'t
+    offer that as an option.
+
+-   OpenSSF Scorecard
+
+    A project seeking to graduate from *Incubation* shall have added the
+    OpenSSF Scorecard generation to its GitHub Actions. A project does not
+    need to score a perfect 10, but should be considered in the green overall.
+
+# Additional considerations
+
+In addition to the above, requirements such as the following may be
+defined at the onset of the project and considered as goals to be met to
+exit *Incubation*:
+
+-   Sufficient real world use
+
+    The project should be used in real applications and not just in
+    demos. Because not all real applications may be discussed publicly,
+    in such cases statements providing as much details as possible
+    should be made.
+
+-   Sufficient scalability
+
+    The project must demonstrate sufficient scalability and document its
+    scalability over various dimensions such as:
+
+    -   Maximum number of transactions per second
+    -   Maximum number of transactions per chain
+    -   Maximum size of a block
+
+-   Minimum test code coverage expected, such as, for example:
+
+    -   Minimum coverage for security & cryptography
+    -   Minimum coverage for other functionality
+    -   Minimum coverage for business logic/smart contract
+
+# Acknowledgements
+
+The above borrows from the [ASF\'s Minimum Graduation Requirements](https://incubator.apache.org/incubation/Incubation_Policy.html#Graduating+from+the+Incubator).
+
+# FIXMEs
+There are a number of items that need to be resolved in our GitHub setup:
+1. Create the following repo [project-proposals](https://github.com/lf-decentralized-trust/project-proposals)
+2. Ensure that there is a GitHub Pages deployment of the above repo

--- a/tac/governing-documents/project-incubation-exit.md
+++ b/tac/governing-documents/project-incubation-exit.md
@@ -151,8 +151,3 @@ exit *Incubation*:
 # Acknowledgements
 
 The above borrows from the [ASF\'s Minimum Graduation Requirements](https://incubator.apache.org/incubation/Incubation_Policy.html#Graduating+from+the+Incubator).
-
-# FIXMEs
-There are a number of items that need to be resolved in our GitHub setup:
-1. Create the following repo [project-proposals](https://github.com/lf-decentralized-trust/project-proposals)
-2. Ensure that there is a GitHub Pages deployment of the above repo

--- a/tac/governing-documents/project-lifecycle.md
+++ b/tac/governing-documents/project-lifecycle.md
@@ -1,0 +1,144 @@
+---
+layout: default
+title: Project Lifecycle
+parent: Governing Documents
+grand_parent: LF Decentralized Trust TAC
+nav_order: 4
+---
+
+[//]: # 'SPDX-License-Identifier: CC-BY-4.0'
+
+# Project Lifecycle
+
+The term "project" within LF Decentralized Trust (LFDT) refers to a
+collaborative endeavor to deliver a work item.
+There may be some projects that are intended to produce a document, such
+as a requirements or use cases document, a whitepaper, or analysis.
+Other projects develop a new capability, refactor, or remove an
+existing capability for the LFDT technology releases. Such
+projects may take the form of a new component (e.g., a new repository) or
+may propose additions, deletions, or changes to an existing
+repository or repositories.
+
+Many other open source initiatives leverage an incubation process for
+new work items. Incubation seems to have the desired effect of encouraging
+new ideas and tracks of work, while at the same time providing clear
+guidance to the broader community as to what is real and supported,
+versus what is still in the exploratory, experimental, or developmental
+phases.
+
+Therefore, LFDT has adopted a similar lifecycle process as
+follows:
+
+![Project Lifecycle](https://kroki.io/graphviz/svg/eNp9jt0KAiEQhe97inmADeq22CAIomdY9sLVaZVMxbQfonfPXTJSq7mbOed8ZwCY6C0xHKTYI71RiXCfQBilGUJz4sRg3elrOx53ivqOOKEVNFRLbWvjrZHYLnN5uoKtJcwThyz1VnBB0XNXz7-mNtoeiXI_MrNXpmB30mOhBVz58eD8wytfSALx6cJD6CGVFpj3Z50REVxrS7k4IxvvcYns3iKqNpFydtjf9Ao-Y0PV4wm6Ap9q)
+
+<!-- diagram source; if you need to update diagram, go to https://kroki.io/#try, choose graphviz, update the diagram, and copy the result of the GET command above.
+  digraph lifecycle {
+    node [shape=box]
+    Incubation [color=purple];
+    Incubation -> Graduated [color=purple, weight=1];
+    Incubation -> Dormant [color=purple, weight=0];
+    Graduated [color=blue];
+    Graduated -> Incubation [color=blue, weight=0];
+    Graduated -> Dormant [color=blue, weight=1];
+    Dormant [color=black];
+    Dormant:e -> Incubation [weight=0];
+    Dormant -> Archived
+    Archived [color=green]
+    Archived:e -> Incubation:e [weight=0, color=green];
+--> 
+
+Projects are in one of four possible states:
+
+- [_Incubation_](#incubation)
+- [_Graduated_](#graduated)
+- [_Dormant_](#dormant)
+- [_Archived_](#archived)
+
+Projects may not necessarily move through those states in a linear way
+and may go through several iterations.
+
+# Proposal
+
+Project Proposals must be submitted to the [TAC] for review, using [Proposal Template].
+Proposals that are approved enter into an _Incubation_ state, unless
+they are of a refactoring nature, in which case the project is turned over
+to the relevant project maintainers to handle as they deem fit.
+
+A Proposal must:
+
+- Have a clear description
+- Have a well-defined scope
+- Identify committed development resources
+- Identify initial maintainers
+- Be vendor neutral
+
+# Incubation
+
+Approved project proposals enter into _Incubation_. For new
+components and modules, a repository is created under the
+[LFDT Github Enterprise](https://github.com/enterprises/lf-decentralized-trust).
+New features or capabilities must be handled through pull requests labeled
+with tags that identify the project and tag it as
+_incubator_. Pull requests ideally are capable of being enabled and disabled with feature-flags.
+
+Projects in _Incubation_ can overlap with one another.
+Entering _Incubation_ is meant to be fairly easy to allow for
+community exploration of different ideas.
+
+After a project qualifies to be declared _Graduated_, the
+_project_ maintainers can then vote to request a graduation
+review by the TAC.
+
+Entering _Incubation_ does not guarantee that the project will
+eventually get to the _Graduated_ state. Projects may never get
+to the _Graduated_ state.
+
+Projects seeking to graduate from _Incubation_ must meet
+the criteria defined in the
+[Incubation Exit Criteria](./project-incubation-exit.md) document.
+
+# Graduated
+
+(Formerly called 'Active') <a id="active"></a>
+
+Projects that have successfully exited the _Incubation_ phase
+are in the _Graduated_ phase.
+
+The TAC may decide to move a _Graduated_ project that no longer meets
+the [Incubation Exit Criteria](./project-incubation-exit.md) back to
+the _Incubation_ state until it meets the criteria again.
+
+# Dormant
+
+(Covers the state formerly known as 'Deprecated') <a id="deprecated"></a>
+
+Projects enter the _Dormant_ state when the normal functions are
+suspended, slowed down for a period of time, or the project is being
+deprecated.
+
+When possible, the maintainers of the project shall vote on such a change
+of state and if it passes, make that recommendation to the TAC, but
+anyone may propose that a project be moved to _Dormant_ state. Members
+of the community who disagree with the request can make their case
+before the TAC. The TAC will consider all points of view and render a
+final decision.
+
+If _Dormant_ projects are re-activated, they re-enter the _Incubation_
+state even if they entered the _Dormant_ state from the _Graduated_ state.
+
+# Archived
+
+(Formerly called 'End of Life')<a id="end-of-life"></a>
+
+Projects that have been in the _Dormant_ state for a period of 6 months
+will be automatically archived.
+
+If anyone wants to resume work on an _Archived_ project they may
+submit a proposal to the TAC for consideration.
+
+If an _Archived_ project is re-activated, it re-enters the _Incubation_
+state independent of its prior history.
+
+[TAC]: https://www.lfdecentralizedtrust.org/staff?department=technical_oversight_committee
+[Proposal Template]: https://lf-decentralized-trust.github.io/project-proposals

--- a/tac/governing-documents/release-taxonomy.md
+++ b/tac/governing-documents/release-taxonomy.md
@@ -1,0 +1,53 @@
+---
+layout: default
+title:  Release Taxonomy
+parent: Governing Documents
+grand_parent: LF Decentralized Trust TAC
+nav_order: 9
+---
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# Release Taxonomy
+
+Releases at LF Decentralized Trust can be done either according to [SemVer](#SemVer) or via [CalVer](#CalVer).
+
+## SemVer
+
+Projects using SemVer follow the system outlined at [semver.org](https://semver.org) [taxonomy][^1]. In addition to the semantic versioning scheme, where we use MAJOR.MINOR.PATCH numbering, following the established guidance given in the semver specification, it is also strongly encouraged that projects should use the following tags, as permitted by semver:
+
+* [preview](#preview)
+* [alpha](#alpha)
+* [beta](#beta)
+* [rcN](#rcn) (release candidate N - where N is 1-n incremented for each candidate)
+* snapshot-&lt;sha&gt;[^2] for interim, possible unstable builds
+
+### preview
+
+Not feature complete, but most functionality is implemented. Any missing functionality that is committed to the production release is identified, and there are specific people working on those features. Not heavily performance tuned, but performance testing has started with the first few hotspots identified and perhaps even addressed. No highest priority issues are in an open state. First-level developer documentation provided to help new developers with the learning curve.
+
+### alpha
+
+Feature complete, for all features committed to the production release. Ready for Proof of Concept-level deployments. Performance can be characterized in a predictable way, so that basic PoC's can be done within the bounds of published expectations. APIs are documented. First attempts at end-user documentation have been made. Developer documentation is further advanced. No highest priority issues are in an open state.
+
+### beta
+
+Feature complete for all features committed to the production release, perhaps with optional features when safe to add. Ready for Pilot-level engagements. Performance is very well characterized and active optimizations are being done, with a target set for the Production release. No highest priority or high priority bugs are in an open state. Developer documentation is complete; end-user documentation is mostly done.
+
+### rcN
+
+For a forthcoming production release, we will prepare multiple candidate releases intended to be heavily tested by the community. As we cycle through resolving uncovered issues, we will issue another when no remaining highest or high priority issues remain, and repeat until we feel confident in releasing a production release, with no qualifier. e.g. 1.0.
+
+## CalVer
+
+Projects may opt to use the [CalVer](https://calver.org) release taxonomy.  Projects that opt in must meet these criteria:
+
+- The project has a regular or semi-regular release schedule that is oriented around release dates.
+- If there are different points in time where different release processes are used, those need to be documented.
+- The project has an established policy for introducing breaking changes.
+  - This policy must allow users sufficient time to adapt to the changes.
+  - This policy must include the channels used to communicate this (such as prominent placement in CHANGELOG files).
+  - Some period of backward compatibility should exist.
+
+[^1]: Note that this is **not** about exiting incubator status.
+
+[^2]: Further, for interim, possibly unstable builds working towards a tagged release, we will append the first seven (7) characters of the SHA-1 hash of the latest commit for the branch from which the build is produced, so that we can identify the commit level of a given test, etc. e.g. 0.6-snapshot-36e99cd

--- a/tac/governing-documents/repository-structure.md
+++ b/tac/governing-documents/repository-structure.md
@@ -31,7 +31,7 @@ format suffixes such as `.md`, `.rst`, or `.txt`.
     -   The current and important past releases
     -   Documentation for developers and users
 -   `MAINTAINERS` \
-    A list of all current maintainers with contact info. [A separate document](MAINTAINERS-file.md)
+    A list of all current maintainers with contact info. [A separate document](./MAINTAINERS-file)
     covers the specifics.
 -   `CONTRIBUTING` \
     Directions on how to contribute code to the project, or a pointer to that information.

--- a/tac/governing-documents/repository-structure.md
+++ b/tac/governing-documents/repository-structure.md
@@ -16,10 +16,9 @@ Repositories MUST have these files with the specific content in the linked files
 link to the specified content with minimal exposition. These files MUST be at the root of the
 repository.
 
--   [`LICENSE`](https://www.apache.org/licenses/LICENSE-2.0.txt) - https://www.apache.org/licenses/LICENSE-2.0.txt\
-    (Unless an exception has been made by the LFDT Governing Board)
--   [`CODE_OF_CONDUCT.md`](./code-of-conduct) - https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct.html
--   [`SECURITY.md`](./security-policy) - https://lf-decentralized-trust.github.io/governance/governing-documents/security-policy.html
+-   [`LICENSE`](https://www.apache.org/licenses/LICENSE-2.0.txt) (Unless an exception has been made by the LFDT Governing Board)
+-   [`CODE_OF_CONDUCT.md`](./code-of-conduct)
+-   [`SECURITY.md`](./security-policy)
 
 ## Required Files with Variable Content
 

--- a/tac/governing-documents/repository-structure.md
+++ b/tac/governing-documents/repository-structure.md
@@ -1,0 +1,82 @@
+---
+layout: default
+title: Common Repository Structure
+parent: Governing Documents
+grand_parent: LF Decentralized Trust TAC
+nav_order: 1
+---
+# Common Repository Structure
+
+LF Decentralized Trust (LFDT) projects are required to maintain a standard set of files in each repository. This
+document describes the required and recommended files.
+
+## Required Files with Specified Content
+
+Repositories MUST have these files with the specific content in the linked files, or a file with a
+link to the specified content with minimal exposition. These files MUST be at the root of the
+repository.
+
+-   [`LICENSE`](https://www.apache.org/licenses/LICENSE-2.0.txt) - https://www.apache.org/licenses/LICENSE-2.0.txt\
+    (Unless an exception has been made by the LFDT Governing Board)
+-   [`CODE_OF_CONDUCT.md`](./code-of-conduct) - https://lf-decentralized-trust.github.io/governance/governing-documents/code-of-conduct.html
+-   [`SECURITY.md`](./security-policy) - https://lf-decentralized-trust.github.io/governance/governing-documents/security-policy.html
+
+## Required Files with Variable Content
+
+Repositories MUST have these files. Named files MUST be at the root of the repository, and may have
+format suffixes such as `.md`, `.rst`, or `.txt`.
+
+-   `README` \
+    A description of the project and contain information or links to information such as
+    -   A reference to the license (required).
+    -   The current and important past releases
+    -   Documentation for developers and users
+-   `MAINTAINERS` \
+    A list of all current maintainers with contact info. [A separate document](MAINTAINERS-file.md)
+    covers the specifics.
+-   `CONTRIBUTING` \
+    Directions on how to contribute code to the project, or a pointer to that information.
+-   `CHANGELOG` \
+    A human readable list of recent changes. Changes should at least include the current release. This
+    file may be maintainer curated or mechanically produced.
+-   Continuous Integration / Continuous Delivery (CI/CD) configurations \
+    Configurations needed to run CI/CD on LFDT Trust provided systems.
+
+## Recommended
+
+Repositories SHOULD have these files. Named files SHOULD be at the root of the repository.
+
+-   `NOTICE`
+    -   As per section 4, subsection (d), of the
+        [Apache License, Version 2](https://www.apache.org/licenses/LICENSE-2.0)
+-   License Header information in each source code file. \
+    For new files added to LFDT repositories they SHOULD include the snippet `SPDX-License-Identifier: Apache-2.0` as part of the header.
+    (see the [Copyright and Licencing Policy](https://wiki.hyperledger.org/display/TSC/Copyright+and+License+Policy))
+-   Build files consistent with the implementation language, such as...
+    -   For JavaScript/Node.js a `package.json` file
+    -   For Ruby a `Gemfile` file
+    -   For Java, one of a Maven `pom.xml`, an Apache Ant `build.xml`, or a Gradle `build.gradle`, file
+    -   For Python `setup.py` and `requirements.txt` files
+    -   For Go `go.mod` and optionally `go.sum` 
+    -   For Rust a `cargo.toml` file
+    -   For multi-lingual repositories a `Makefile` or executable `build.sh` script
+    -   For other languages, other standard build files a practitioner of the language would expect.
+-   Testing code \
+    Code to test the code in the repository (such as unit tests), in a location appropriate for the language.
+    \
+    Not all repositories can be tested (homebrew, docs), which is the only reason this is a SHOULD.
+
+## Prohibited
+
+Repositories MUST NOT have these files.
+
+-   Executable binaries and shared library files built by code in the repository \
+    This includes `.exe`, `.dll`, `.so`, `.a` and `.dylib` files not otherwise part of a third party
+    library.
+
+# Tooling
+
+In order to help automate checks a repolinter file and supporting scripts can be found in
+[LFDT Community Management Tools](https://github.com/hyperledger-labs/hyperledger-community-management-tools/tree/main/repo_structure).
+
+Note that this document takes precedence over documents in the folder linked above, wherever the instructions and tooling differ between the two.


### PR DESCRIPTION
Initial version that needs some re-work with changes to the way LFDT is structured, including changes for JDF-type projects and also for GitHub enterprise structure.