### PR TITLE
TAC meeting on 14th November 2024

### DIFF
--- a/tac/meeting-minutes/2024/2024-11-14.md
+++ b/tac/meeting-minutes/2024/2024-11-14.md
@@ -1,0 +1,53 @@
+---
+layout: default
+title: 2024-11-14
+parent: 2024 Meeting Minutes
+grand_parent: Meeting Minutes
+---
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the LF Decentralized Trust Community](../images/all-are-welcome.png "All are Welcome in the LF Decentralized Trust Community")
+
+Linux Foundation Decentralized Trust is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [LF Decentralized Trust Code of Conduct](../../governing-documents/code-of-conduct).
+
+# Announcements
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [leave a comment for consideration on the upcoming newsletter wiki page](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17172152/2024).
+- If you are [eligible to vote in the TAC 2025 election](https://lf-decentralized-trust.github.io/tac-eligibility-check/), please visit [this link](https://vote.heliosvoting.org/helios/e/2025-LF-Decentralized-Trust-TAC-election) while logged in to GitHub and vote. Voting ends [14 Nov 2024](../../member-info/election-timeline.md). The top six will be on the TAC; the board will then choose five people to fill the remaining seats.
+
+# Quarterly reports
+- [2024 Q4 Hyperledger Aries](https://github.com/LF-Decentralized-Trust/governance/pull/67)
+- [2024 Q4 Hyperledger Indy](https://github.com/LF-Decentralized-Trust/governance/pull/68)
+- [2024 Q4 Hyperledger AnonCreds](https://github.com/LF-Decentralized-Trust/governance/pull/66)
+- [2024 Q4 Hyperledger Cacti](https://github.com/LF-Decentralized-Trust/governance/pull/69)
+- [2024 Q4 Hyperledger Iroha](https://github.com/LF-Decentralized-Trust/governance/pull/70)
+
+# Overdue reports
+
+# Upcoming reports
+**NOTE:** All Q4 project updates should be checked into the new [LFDT site](https://github.com/lf-decentralized-trust/governance) under the `tac/project-updates` folder.
+
+- 2024 Q4 Hyperledger Bevel (due November 14, 2024)
+- [2024 TAC Project Update Calendar](../../project-updates/2024/2024-schedule)
+
+# Discussion
+- [New project proposal](https://github.com/LF-Decentralized-Trust/project-proposals/pull/23)
+
+# Recordings
+- [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Upcoming meetings
+- [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Stephen Curran
+- [ ] David Enyeart
+- [ ] Tracy Kuhrt
+- [ ] Yacov Manevich
+- [ ] Matt Nelson
+- [ ] Venkatraman Ramakrishna
+- [ ] Arun S M
+- [ ] Peter Somogyvari
+- [ ] Conor Svensson
+- [ ] Jim Zhang

--- a/tac/meeting-minutes/2024/2024-11-14.md
+++ b/tac/meeting-minutes/2024/2024-11-14.md
@@ -40,14 +40,14 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Attended by
 
-- [ ] Marcus Brandenburger
-- [ ] Stephen Curran
-- [ ] David Enyeart
-- [ ] Tracy Kuhrt
-- [ ] Yacov Manevich
-- [ ] Matt Nelson
-- [ ] Venkatraman Ramakrishna
-- [ ] Arun S M
-- [ ] Peter Somogyvari
-- [ ] Conor Svensson
-- [ ] Jim Zhang
+- [ ] ~~Marcus Brandenburger~~
+- [x] Stephen Curran
+- [x] David Enyeart
+- [ ] ~~Tracy Kuhrt~~
+- [ ] ~~Yacov Manevich~~
+- [ ] ~~Matt Nelson~~
+- [x] Venkatraman Ramakrishna
+- [x] Arun S M
+- [x] Peter Somogyvari
+- [ ] ~~Conor Svensson~~
+- [ ] ~~Jim Zhang~~


### PR DESCRIPTION
1. Add meeting agenda.
2. New project proposal.
3. Pending quarterly report reviews.
4. Reminders to the TAC.