### PR TITLE
docs: update CHANGELOG requirement and suggest conventional commits

### DIFF
--- a/tac/governing-documents/repository-structure.md
+++ b/tac/governing-documents/repository-structure.md
@@ -36,9 +36,6 @@ format suffixes such as `.md`, `.rst`, or `.txt`.
     covers the specifics.
 -   `CONTRIBUTING` \
     Directions on how to contribute code to the project, or a pointer to that information.
--   `CHANGELOG` \
-    A human readable list of recent changes. Changes should at least include the current release. This
-    file may be maintainer curated or mechanically produced.
 -   Continuous Integration / Continuous Delivery (CI/CD) configurations \
     Configurations needed to run CI/CD on LFDT Trust provided systems.
 

--- a/tac/governing-documents/repository-structure.md
+++ b/tac/governing-documents/repository-structure.md
@@ -74,6 +74,10 @@ Repositories SHOULD have these files. Named files SHOULD be at the root of the r
     -   Contains a list of notable usages of the project's releases and/or source code
     -   MUST contain publicly verifiable references in the form of URLs or article info
     -   Can be updated by maintainers as well as by adopters or any third party who is aware of adoption and can provide verifiable links.
+-   `CHANGELOG` \
+    A human-readable list of recent changes. Changes should at least include the current release. This
+    file may be maintainer curated or mechanically produced. Consider making this file a link that points to
+    the GitHub release notes.
 
 ## Prohibited
 

--- a/tac/guidelines/project-best-practices.md
+++ b/tac/guidelines/project-best-practices.md
@@ -148,6 +148,8 @@ The [Project Incubation Exit Criteria](../governing-documents/project-incubation
   - NPM packages - don't publish on every commit due to NPM limit of 1000 versions
 * Changelog and Release Notes - whenever possible, do not create a `CHANGELOG.md` file inside the repository. Use the
     Release Notes available through GitHub to capture new features or bug fixes in a specific release.
+* Consider the use of [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate 
+    major.minor.patch release identifiers.
 
 ## Continuous Integration
 

--- a/tac/guidelines/project-best-practices.md
+++ b/tac/guidelines/project-best-practices.md
@@ -146,8 +146,9 @@ The [Project Incubation Exit Criteria](../governing-documents/project-incubation
 * Release artifacts
   - binaries attached to GitHub release
   - NPM packages - don't publish on every commit due to NPM limit of 1000 versions
-* Changelog and Release Notes - whenever possible, do not create a `CHANGELOG.md` file inside the repository. Use the
-    Release Notes available through GitHub to capture new features or bug fixes in a specific release.
+* Changelog and Release Notes - In new repositories, do not create a `CHANGELOG.md` file inside the repository. Use the
+    Release Notes available through GitHub to capture new features or bug fixes in a specific release. It is at 
+    maintainer discretion to use a changelog file if the existing repository is effectively using a changelog.
 * Consider the use of [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate 
     major.minor.patch release identifiers.
 

--- a/tac/guidelines/project-best-practices.md
+++ b/tac/guidelines/project-best-practices.md
@@ -146,6 +146,8 @@ The [Project Incubation Exit Criteria](../governing-documents/project-incubation
 * Release artifacts
   - binaries attached to GitHub release
   - NPM packages - don't publish on every commit due to NPM limit of 1000 versions
+* Changelog and Release Notes - whenever possible, do not create a `CHANGELOG.md` file inside the repository. Use the
+    Release Notes available through GitHub to capture new features or bug fixes in a specific release.
 
 ## Continuous Integration
 

--- a/tac/guidelines/project-best-practices.md
+++ b/tac/guidelines/project-best-practices.md
@@ -146,11 +146,9 @@ The [Project Incubation Exit Criteria](../governing-documents/project-incubation
 * Release artifacts
   - binaries attached to GitHub release
   - NPM packages - don't publish on every commit due to NPM limit of 1000 versions
-* Changelog and Release Notes - In new repositories, do not create a `CHANGELOG.md` file inside the repository. Use the
-    Release Notes available through GitHub to capture new features or bug fixes in a specific release. It is at 
-    maintainer discretion to use a changelog file if the existing repository is effectively using a changelog.
-* Consider the use of [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to automate 
-    major.minor.patch release identifiers.
+* Release Notes - Use the Release Notes available through GitHub to capture new features or bug fixes in a specific
+     release. Consider the use of [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to
+     automate major.minor.patch release identifiers.
 
 ## Continuous Integration
 


### PR DESCRIPTION
This PR updates 2 specific items:

1. Remove the requirement to have a `CHANGELOG.md` file in the repository. This is following industry best practices. Instead, use the GitHub release notes to attach release notes to a release.
2. Suggest the use of conventional commits for automatic release versioning (major.minor.patch).