### PR TITLE
Add meeting agenda for 16th April 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
   - Meetings:
     - meeting-minutes/index.md
     - 2026:
+      - 2026-04-16: meeting-minutes/2026/2026-04-16.md
       - 2026-04-09: meeting-minutes/2026/2026-04-09.md
       - 2026-04-02: meeting-minutes/2026/2026-04-02.md
       - 2026-03-26: meeting-minutes/2026/2026-03-26.md

--- a/tac/meeting-minutes/2026/2026-04-16.md
+++ b/tac/meeting-minutes/2026/2026-04-16.md
@@ -18,11 +18,10 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 - [Hyperledger Iroha Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/310) - Rama, Osama
 - [Paladin Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/313) - Rama, Diane
 - [Indy Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/284) - Matthew, Kevin
+- [Besu Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/318)
 
 # Overdue reports
 - Hyperledger Solang Annual Report (due February 12, 2026)
-- Besu Annual Report (due February 26, 2026)
-- Caliper Annual Report (due March 5, 2026)
 - Credebl Annual Report (due March 12, 2026)
 - ToIP Annual Report (due March 12, 2026)
 - Smoot Annual Report (due March 19, 2026)

--- a/tac/meeting-minutes/2026/2026-04-16.md
+++ b/tac/meeting-minutes/2026/2026-04-16.md
@@ -18,7 +18,7 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 - [Hyperledger Iroha Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/310) - Rama, Osama
 - [Paladin Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/313) - Rama, Diane
 - [Indy Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/284) - Matthew, Kevin
-- [Besu Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/318)
+- [Besu Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/318) - Yoav, Enrique
 
 # Overdue reports
 - Hyperledger Solang Annual Report (due February 12, 2026)
@@ -47,14 +47,14 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Attended by
 
-- [ ] Marcus Brandenburger
-- [ ] Hendrik Ebbers
-- [ ] Kanchan Kaur
-- [ ] Kevin Millikin
-- [ ] Enrique Lacal
-- [ ] Diane Mueller
-- [ ] Venkatraman Ramakrishna
-- [ ] Osama Rabea
-- [ ] Arun S M
-- [ ] Yoav Tock
-- [ ] Matthew Whitehead
+- [ ] ~~Marcus Brandenburger~~
+- [x] Hendrik Ebbers
+- [ ] ~~Kanchan Kaur~~
+- [ ] ~~Kevin Millikin~~
+- [ ] ~~Enrique Lacal~~
+- [x] Diane Mueller
+- [ ] ~~Venkatraman Ramakrishna~~
+- [ ] ~~Osama Rabea~~
+- [x] Arun S M
+- [x] Yoav Tock
+- [x] Matthew Whitehead

--- a/tac/meeting-minutes/2026/2026-04-16.md
+++ b/tac/meeting-minutes/2026/2026-04-16.md
@@ -1,0 +1,61 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the LF Decentralized Trust Community](../images/all-are-welcome.png "All are Welcome in the LF Decentralized Trust Community")
+
+Linux Foundation Decentralized Trust is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [LF Decentralized Trust Code of Conduct](../../governing-documents/code-of-conduct.md).
+
+# Meeting Link
+- [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96405933609?password=dc76428e-6a2d-435f-a020-a590bc4b94a4)
+
+# Announcements
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [leave a comment for consideration on the upcoming newsletter wiki page](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/697270275/2026).
+
+# Annual reports
+- [Web3J Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/294) - Marcus, Kanchan
+- [Lockness Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/298) - Matthew, Hendrik
+- [Hiero Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/299) - Enrique, Kanchan
+- [Hyperledger Iroha Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/310) - Rama, Osama
+- [Paladin Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/313) - Rama, Diane
+- [Indy Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/284) - Matthew, Kevin
+
+# Overdue reports
+- Hyperledger Solang Annual Report (due February 12, 2026)
+- Besu Annual Report (due February 26, 2026)
+- Caliper Annual Report (due March 5, 2026)
+- Credebl Annual Report (due March 12, 2026)
+- ToIP Annual Report (due March 12, 2026)
+- Smoot Annual Report (due March 19, 2026)
+- Minokawa Annual Report (due March 19, 2026)
+
+# Upcoming reports
+- [2026 TAC Project Update Calendar](../../project-updates/2026/2026-schedule.md)
+
+# Labs summary
+- [Onboarding Diagnostics Lab](https://github.com/LF-Decentralized-Trust-labs/LF-Decentralized-Trust-labs.github.io/pull/374)
+
+# Discussion
+- Project report reviews, find the [TAC member assignment worksheet](https://docs.google.com/spreadsheets/d/1u1yKuu8dl00ie-Nsm1sFJcIF82njYJw0swfEidx5Foo/edit?gid=1376954816#gid=1376954816) for reviews.
+- GenAI usage and guidelines - Rafael ([cacti PR #4164](https://github.com/hyperledger-cacti/cacti/pull/4164)).
+- How TAC can actively promote and guide project teams toward SLSA-aligned best practices?
+- Framework for assigning phases/maturity levels to sub‑projects independently (e.g., Fabric vs. Fabric‑X).
+
+# Recordings
+- [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Upcoming meetings
+- [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Hendrik Ebbers
+- [ ] Kanchan Kaur
+- [ ] Kevin Millikin
+- [ ] Enrique Lacal
+- [ ] Diane Mueller
+- [ ] Venkatraman Ramakrishna
+- [ ] Osama Rabea
+- [ ] Arun S M
+- [ ] Yoav Tock
+- [ ] Matthew Whitehead


### PR DESCRIPTION
## Summary
- 6 annual reports in review (Web3J, Lockness, Hiero, Iroha, Paladin, Indy)
- 7 overdue reports with no PR submitted (Solang, Besu, Caliper, Credebl, ToIP, Smoot, Minokawa)
- 1 lab proposal for discussion (Onboarding Diagnostics Lab)
- Discussion topics: project report reviews, GenAI usage and guidelines, SLSA best practices enforcement, sub-project maturity framework