### PR TITLE
Update the governance docs to move from quarterly to twice-yearly reports

### DIFF
--- a/tac/governing-documents/MAINTAINERS-file.md
+++ b/tac/governing-documents/MAINTAINERS-file.md
@@ -33,8 +33,7 @@ each Maintainer given one or more of those designated scopes:
   - The LFDT TAC manages a team per LFDT Project that includes all contributors to the project. That team is given the "Read" GitHub role in all project repositories. This team need not be documented in the "MAINTAINERS" file.
 - Maintainers **MAY** define Maintainer scopes within a repository that don't require
   elevated GitHub privileges. For example, a scope might include hosting
-  community meetings, or contributing to the LFDT Project's Quarterly
-  report.
+  community meetings, or contributing to the LFDT Project's mid-year report.
 
 If there is more than the single "Maintainer" scope used in a repository, there **MUST** be a list of the repository specific scopes in the MAINTAINERS file. The list must include the scope name, the definition of the scope, and if applicable, the related GitHub Role and Team for the scope.
 
@@ -73,7 +72,7 @@ The following table format **MUST** be used for both Maintainers lists (active a
 
 The `MAINTAINERS.md` file **SHOULD** contain information about the different
 maintainer scopes, and for each, the maintainers duties (e.g., maintainers
-calls, quarterly reports, code reviews, issue cleansing). See the [Sample
+calls, mid-year reports, code reviews, issue cleansing). See the [Sample
 Maintainers](./SAMPLE-MAINTAINERS.md) for an example of what to include in this
 section for an open source software project. Feel free to evolve that text to
 match the needs of the repository and project.

--- a/tac/governing-documents/SAMPLE-MAINTAINERS.md
+++ b/tac/governing-documents/SAMPLE-MAINTAINERS.md
@@ -53,7 +53,7 @@ Maintainers are expected to perform the following duties for this repository. Th
 - Monitor requests from the LF Decentralized Trust Technical Advisory Council about the
 contents and management of LFDT repositories, such as branch handling,
 required files in repositories and so on.
-- Contribute to the LFDT Project's Quarterly Report.
+- Contribute to the LFDT Project's Mid-Year Report.
 
 ## Becoming a Maintainer
 

--- a/tac/governing-documents/project-annual-review.md
+++ b/tac/governing-documents/project-annual-review.md
@@ -1,14 +1,14 @@
-[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+[//]: # "SPDX-License-Identifier: CC-BY-4.0"
 
 # Project Annual Review
 
 ## Overview
 
-In addition to the [quarterly project updates](./project-updates.md), projects will undergo an annual review by the TAC. This annual review will replace one of the quarterly reports. Unlike the quarterly updates, the annual review process will be a "big picture" assessment of the project by reviewing the progress on goals from the prior year and goals for the next year. In addition, the annual review process will include a deep dive into the project health, including contributor and maintainer diversity and adoption metrics, and will include an assessment of the current [project lifecycle state](./project-lifecycle.md). The review will result in a set of recommendations for the project to improve and/or recommendation to move a project to another state.
+In addition to the [mid-year project updates](./project-updates.md), projects will undergo an annual review by the TAC. Unlike the mid-year updates, the annual review process will be a "big picture" assessment of the project by reviewing the progress on goals from the prior year and goals for the next year. In addition, the annual review process will include a deep dive into the project health, including contributor and maintainer diversity and adoption metrics, and will include an assessment of the current [project lifecycle state](./project-lifecycle.md). The review will result in a set of recommendations for the project to improve and/or recommendation to move a project to another state.
 
 ## Timeline
 
-Annual reviews will replace the Q1 quarterly report.  **If a project's annual review is not submitted within two months of notification, the TAC will take this as a sign that the project is not under active maintenance and is likely to decide to archive the project and move it to End of Life status.**
+ **If a project's annual review is not submitted within two months of notification, the TAC will take this as a sign that the project is not under active maintenance and is likely to decide to archive the project and move it to End of Life status.**
 
 **NOTE:** If a project has genuinely stalled the project's TSC (or similar) can save everyone’s time and effort by archiving the project and moving it to `End of Life`.
 
@@ -31,7 +31,7 @@ LF Decentralized Trust staff will notify the project TSC and copy the TAC when t
 
 Project TSC members are responsible for agreeing between them who will complete the annual review. One of the project's TSC members (or maintainer) should create the review in GitHub under [lf-decentralized-trust/governance] in the `/tac/project-updates/` folder.
 
-- Raise a PR titled *`[year] [Project Name] Annual Review`* (e.g., `2024 Amazing Annual Review`).
+- Raise a PR titled _`[year] [Project Name] Annual Review`_ (e.g., `2024 Amazing Annual Review`).
 - The PR should include a file called `./<year>/annual-<Project-Name>.md` (e.g., `2024/annual-amazing.md`) using [the annual review instructions](../project-updates/annual-review-instructions.md).
 - Send an email to the [TAC mailing list] so that the community knows the PR is there and can comment on it.
 
@@ -67,8 +67,8 @@ NOTE: If the TAC members recommend moving to a new status, additional work may b
 - Reviewing the contents of the PR and analyzing the project's community health indicators.
 - Coordinating with the secondary TAC member on their findings prior to the TAC meeting.
 - Documenting their findings within the pull request for discussion. The thread should contain:
-    1. Important facts about the project that could influence the TAC's decision around the future of the project, its current status, and paths to other statuses.
-    2. Whether the project's view of themselves is accurate and the ask of the TAC is reasonable to assist the project moving forward.
+  1. Important facts about the project that could influence the TAC's decision around the future of the project, its current status, and paths to other statuses.
+  2. Whether the project's view of themselves is accurate and the ask of the TAC is reasonable to assist the project moving forward.
 - Lead the annual review discussion at the TAC meeting, providing a summary of the project by leveraging the private thread's content as the basis of discussion. The discussion typically focuses on what is going well with the project and areas to improve.
 - After the public meeting wraps up, summarizing the discussion in a new PR that updates the annual report. In addition to the summary, a link to the recording where the annual report was discussed should be included.
 - Capture any action items by filing issues in the [lf-decentralized-trust/governance] GitHub repo.

--- a/tac/governing-documents/project-lifecycle.md
+++ b/tac/governing-documents/project-lifecycle.md
@@ -143,7 +143,7 @@ The TAC must evaluate a project's lifecycle state during its [annual review](./p
 - Upgrade (e.g., *Incubation* to *Graduated*)
 - Downgrade (e.g., *Graduated* to *Dormant*)
 
-In addition, a project's lifecycle state should be evaluated during the quarterly updates if the TAC sees that a project is struggling to meet the requirements of its current state.
+In addition, a project's lifecycle state should be evaluated during the mid-year update if the TAC sees that a project is struggling to meet the requirements of its current state.
 
 (*Note*: as a rough hierarchy, the *Graduated* state represents the highest maturity, followed by *Incubated*, followed by *Dormant*, followed by *Archived*.)
 

--- a/tac/governing-documents/project-updates.md
+++ b/tac/governing-documents/project-updates.md
@@ -17,7 +17,7 @@ Project updates are to be submitted as a pull request to the [LF-Decentralized-T
 
 !!! success "Important Timing Note"
 
-    If project updates are not submitted within two months of their scheduled due date or if pull request comments are not responded to within three weeks, projects will be moved to a [Dormant state](./project-lifecycle.md/#dormant)! New projects may be granted an extension for one quarter for submission, but no more.
+    If project updates are not submitted within two months of their scheduled due date or if pull request comments are not responded to within three weeks, projects will be moved to a [Dormant state](./project-lifecycle.md/#dormant)! New projects may be granted an extension for one mid-year submission, but no more.
 
 ## Merging
 Project updates will be merged after 14 days from submission unless (1) there is still ongoing discussion regarding the report or (2) a majority of the TAC has not approved the PR. If all TAC members have approved the PR before 14 days, then the PR will be merged.

--- a/tac/guidelines/project-incubation-entry-considerations.md
+++ b/tac/guidelines/project-incubation-entry-considerations.md
@@ -27,7 +27,7 @@ A project is more likely to succeed if it publicly states its intent and estimat
         1. Working to diversify contributors and maintainers from the initial set of contributing organizations
         1. Mentoring new contributors to become maintainers
     1. Supporting public, community forums (e.g. GitHub, Discord)
-    1. Submitting annual and quarterly reports to the TAC in a timely fashion
+    1. Submitting annual and mid-year reports to the TAC in a timely fashion
 
 If you need any assistance with community engagement planning, LFDT staff is happy to help.
 

--- a/tac/member-info/tac-chair-notes.md
+++ b/tac/member-info/tac-chair-notes.md
@@ -14,7 +14,7 @@ Each week on Monday or Tuesday, the agenda needs to be created and distributed.
 
 To create the TAC agenda, there are two places that are always used.
 
-1. [Governance Repo](https://github.com/lf-decentralized-trust/governance) - in this repo, the pull requests will be used for both determining which project updates are ready for review and need to be included in either the _Project Updates_ section of the agenda (for quarterly reports) or the _Discussion_ section of the agenda (for annual reports). In addition, there may be other governance pull requests that should be included in the discussion portion of the agenda. The issues can be used for determining if there are topics that should be discussed and included in the _Discussion_ section of the agenda that may not yet have a pull request available.
+1. [Governance Repo](https://github.com/lf-decentralized-trust/governance) - in this repo, the pull requests will be used for both determining which project updates are ready for review and need to be included in either the _Project Updates_ section of the agenda (for mid-year reports) or the _Discussion_ section of the agenda (for annual reports). In addition, there may be other governance pull requests that should be included in the discussion portion of the agenda. The issues can be used for determining if there are topics that should be discussed and included in the _Discussion_ section of the agenda that may not yet have a pull request available.
 1. [Project Proposals](https://github.com/lf-decentralized-trust/project-proposals) - in this repo, the pull requests will be used to determine if there are any new project proposals that need to be discussed and included in the _Discussion_ section of the agenda.
 
 Meeting agendas will be added to the `mkdocs.yml` file under _Meetings_ section in the appropriate year in reverse chronological order. A new file named `YYYY-MM-DD.md` will be placed under `tac/meeting-minutes/yyyy` folder.
@@ -23,7 +23,7 @@ Meeting agendas will be added to the `mkdocs.yml` file under _Meetings_ section 
 
 After creating the TAC agenda, a pull request will be created against the [Governance Repo](https://github.com/lf-decentralized-trust/governance). An example of such a pull request can be seen at: https://github.com/LF-Decentralized-Trust/governance/pull/248.
 
-In addition, a new thread should be created in the **#tac** channel in Discord named `Month dd, YYYY Meeting`.  The `@TAC Members` group should be included, as well as, a link to the agenda in the thread. An example of such a thread can be seen at: https://discord.com/channels/905194001349627914/941384040316018790/1435665707718279271.
+In addition, a new thread should be created in the **#tac** channel in Discord named `Month dd, YYYY Meeting`. The `@TAC Members` group should be included, as well as, a link to the agenda in the thread. An example of such a thread can be seen at: https://discord.com/channels/905194001349627914/941384040316018790/1435665707718279271.
 
 Lastly, an email should be sent to the tac@lists.lfdecentralizedtrust.org. An example of such an email can be seen at: https://lists.lfdecentralizedtrust.org/g/tac/message/4165.
 
@@ -35,20 +35,20 @@ The following is the general flow for all TAC meetings that has been followed fo
 1. Cover the Antitrust Policy
 1. Cover the Code of Conduct (usually just pointing out that everyone is welcome and should respect each other and letting people know that the full text of the code of conduct is available in the agenda)
 1. Announcements
-    1. Official announcements always include a call for contributions to the /dev/weekly developer newsletter and any other announcements that may be relevant, such as upcoming webinars, reminders, and timelines for elections
-    1. Ask if there are any other announcements that anyone would like to make
+   1. Official announcements always include a call for contributions to the /dev/weekly developer newsletter and any other announcements that may be relevant, such as upcoming webinars, reminders, and timelines for elections
+   1. Ask if there are any other announcements that anyone would like to make
 1. Project Updates
-    1. Remind people of submitted reports and discuss any open questions on those reports
-    1. Remind people of upcoming due reports
-    1. Remind people of any overdue reports (note it is the TAC vice-chairs responsibility to follow up on these so may be worth asking if they have any updates)
+   1. Remind people of submitted reports and discuss any open questions on those reports
+   1. Remind people of upcoming due reports
+   1. Remind people of any overdue reports (note it is the TAC vice-chairs responsibility to follow up on these so may be worth asking if they have any updates)
 1. Discussion Items
-    1. Governance Updates
-    1. Annual Review Discussions
-    1. New Project Proposals
-    1. Task Force Updates
+   1. Governance Updates
+   1. Annual Review Discussions
+   1. New Project Proposals
+   1. Task Force Updates
 1. Closing Meeting
-    1. Ask if there is anything else that needs to be covered before ending the meeting
-    1. Remind attendees of what might be on the agenda for next week (also a good way to ensure that there will be an agenda)
+   1. Ask if there is anything else that needs to be covered before ending the meeting
+   1. Remind attendees of what might be on the agenda for next week (also a good way to ensure that there will be an agenda)
 
 ### Initial Meeting
 
@@ -56,7 +56,7 @@ During the first meeting of the TAC term, I have been using that as an opportuni
 
 ### First Quarter Meetings
 
-For the past few years, these meetings have been dedicated to reviewing the annual reviews for each of the projects. This consisted of a readout from the primary and secondary TAC reviewers; however, it has been suggested that in addition to these readouts, the project maintainers or TSC representatives should first present the annual review before the readout. NOTE: It will be important to limit the time (possibly 10 minutes) for the presentation to ensure that there is enough time for the readout. 
+For the past few years, these meetings have been dedicated to reviewing the annual reviews for each of the projects. This consisted of a readout from the primary and secondary TAC reviewers; however, it has been suggested that in addition to these readouts, the project maintainers or TSC representatives should first present the annual review before the readout. NOTE: It will be important to limit the time (possibly 10 minutes) for the presentation to ensure that there is enough time for the readout.
 
 NOTE: The TAC primary and secondary reviewers needs to be assigned by the TAC chair. I have typically done this by asking the TAC members to note their conflict of interests for projects and then assigning to ensure that members with conflicts are not assigned to those projects.
 
@@ -64,7 +64,7 @@ An example of this can be found in [Annual Reports 2025](https://docs.google.com
 
 ### Remainder of Year Meetings
 
-The other meetings during the year are driven by the goals that the TAC has set out for the year and any other items that require attention. These meetings generally focus on 
+The other meetings during the year are driven by the goals that the TAC has set out for the year and any other items that require attention. These meetings generally focus on
 
 1. Governance Updates
 1. Annual Review Discussions
@@ -82,7 +82,7 @@ For the past couple of years, one of the final meeting of the year is reserved f
 
 ## Providing TAC and Project Updates to the Governing Board
 
-Each month, you are responsbible for representing the TAC and the projects to the Governing Board. The LFDT project manager (currently Min Yu) will reach out to you a week prior to the due date to let you know that the update is due. During this update, I have typically provided an update on what the TAC is up to (e.g., decisions made, discussions had) and then provide a short update on the annual reviews or quarterly updates provided by the projects. You can see previous updates since November, 2021 under [Governing Board Updates](https://drive.google.com/drive/folders/1tO6UwQ4ezDYYuC2bjQRK1ORPjSq5n38U?usp=sharing).
+Each month, you are responsbible for representing the TAC and the projects to the Governing Board. The LFDT project manager (currently Min Yu) will reach out to you a week prior to the due date to let you know that the update is due. During this update, I have typically provided an update on what the TAC is up to (e.g., decisions made, discussions had) and then provide a short update on the annual reviews or mid-year updates provided by the projects. You can see previous updates since November, 2021 under [Governing Board Updates](https://drive.google.com/drive/folders/1tO6UwQ4ezDYYuC2bjQRK1ORPjSq5n38U?usp=sharing).
 
 ## Conference and Webinar Updates
 

--- a/tac/member-info/tac-responsibilities.md
+++ b/tac/member-info/tac-responsibilities.md
@@ -39,4 +39,4 @@ The TAC Chair has the following additional responsibilities:
 The TAC Vice Chair has the following additional responsibilities:
 
 * Running the TAC meetings when the chair is unable
-* Reaching out to projects when they miss submitting their TAC Quarterly Project Update to remind the projects that they have a report due
+* Reaching out to projects when they miss submitting their TAC Mid-Year Project Update to remind the projects that they have a report due

--- a/tac/project-updates/2026/2026-schedule.md
+++ b/tac/project-updates/2026/2026-schedule.md
@@ -1,80 +1,44 @@
-[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+[//]: # "SPDX-License-Identifier: CC-BY-4.0"
 
 # 2026 Schedule
 
-**NOTE:** The Q1 report is reserved for the [project annual review](../../governing-documents/project-annual-review.md).
+**NOTE:** The H1 report is the [project annual review](../../governing-documents/project-annual-review.md).
 
 | Quarter     | Date       | Project   |
 | ----------- | ---------- | --------- |
-| Q1 (annual) | 2026-01-22 | Cacti     |
-| Q1 (annual) | 2026-01-22 | Fabric    |
-| Q1 (annual) | 2026-01-29 | Identus   |
-| Q1 (annual) | 2026-01-29 | Web3j     |
-| Q1 (annual) | 2026-02-05 | Indy      |
-| Q1 (annual) | 2026-02-05 | AnonCreds |
-| Q1 (annual) | 2026-02-12 | Iroha     |
-| Q1 (annual) | 2026-02-12 | Solang    |
-| Q1 (annual) | 2026-02-26 | Firefly   |
-| Q1 (annual) | 2026-02-26 | Besu      |
-| Q1 (annual) | 2026-03-05 | Caliper   |
-| Q1 (annual) | 2026-03-05 | Lockness  |
-| Q1 (annual) | 2026-03-05 | Hiero     |
-| Q1 (annual) | 2026-03-12 | Credebl   |
-| Q1 (annual) | 2026-03-12 | ToIP      |
-| Q1 (annual) | 2026-03-19 | Paladin   |
-| Q1 (annual) | 2026-03-19 | Smoot     |
-| Q1 (annual) | 2026-03-19 | Minokawa  |
-| Q2          | 2026-04-23 | Cacti     |
-| Q2          | 2026-04-23 | Fabric    |
-| Q2          | 2026-04-30 | Identus   |
-| Q2          | 2026-04-30 | Web3j     |
-| Q2          | 2026-05-07 | Indy      |
-| Q2          | 2026-05-07 | AnonCreds |
-| Q2          | 2026-05-14 | Iroha     |
-| Q2          | 2026-05-14 | Solang    |
-| Q2          | 2026-05-21 | Firefly   |
-| Q2          | 2026-05-21 | Besu      |
-| Q2          | 2026-05-28 | Caliper   |
-| Q2          | 2026-05-28 | Lockness  |
-| Q2          | 2026-05-28 | Hiero     |
-| Q2          | 2026-06-04 | Credebl   |
-| Q2          | 2026-06-04 | ToIP      |
-| Q2          | 2026-06-11 | Paladin   |
-| Q2          | 2026-06-11 | Smoot     |
-| Q2          | 2026-06-11 | Minokawa  |
-| Q3          | 2026-07-23 | Cacti     |
-| Q3          | 2026-07-23 | Fabric    |
-| Q3          | 2026-07-30 | Identus   |
-| Q3          | 2026-07-30 | Web3j     |
-| Q3          | 2026-08-06 | Indy      |
-| Q3          | 2026-08-06 | AnonCreds |
-| Q3          | 2026-08-13 | Iroha     |
-| Q3          | 2026-08-13 | Solang    |
-| Q3          | 2026-08-20 | Firefly   |
-| Q3          | 2026-08-20 | Besu      |
-| Q3          | 2026-08-27 | Caliper   |
-| Q3          | 2026-08-27 | Lockness  |
-| Q3          | 2026-08-27 | Hiero     |
-| Q3          | 2026-09-03 | Credebl   |
-| Q3          | 2026-09-03 | ToIP      |
-| Q3          | 2026-09-10 | Paladin   |
-| Q3          | 2026-09-10 | Smoot     |
-| Q3          | 2026-09-10 | Minokawa  |
-| Q4          | 2026-10-22 | Cacti     |
-| Q4          | 2026-10-22 | Fabric    |
-| Q4          | 2026-10-29 | Identus   |
-| Q4          | 2026-10-29 | Web3j     |
-| Q4          | 2026-11-05 | Indy      |
-| Q4          | 2026-11-05 | AnonCreds |
-| Q4          | 2026-11-12 | Iroha     |
-| Q4          | 2026-11-12 | Solang    |
-| Q4          | 2026-11-19 | Firefly   |
-| Q4          | 2026-11-19 | Besu      |
-| Q4          | 2026-11-26 | Caliper   |
-| Q4          | 2026-11-26 | Lockness  |
-| Q4          | 2026-11-26 | Hiero     |
-| Q4          | 2026-12-03 | Credebl   |
-| Q4          | 2026-12-03 | ToIP      |
-| Q4          | 2026-12-10 | Paladin   |
-| Q4          | 2026-12-10 | Smoot     |
-| Q4          | 2026-12-10 | Minokawa  |
+| 1H (annual) | 2026-01-22 | Cacti     |
+| 1H (annual) | 2026-01-22 | Fabric    |
+| 1H (annual) | 2026-01-29 | Identus   |
+| 1H (annual) | 2026-01-29 | Web3j     |
+| 1H (annual) | 2026-02-05 | Indy      |
+| 1H (annual) | 2026-02-05 | AnonCreds |
+| 1H (annual) | 2026-02-12 | Iroha     |
+| 1H (annual) | 2026-02-12 | Solang    |
+| 1H (annual) | 2026-02-26 | Firefly   |
+| 1H (annual) | 2026-02-26 | Besu      |
+| 1H (annual) | 2026-03-05 | Caliper   |
+| 1H (annual) | 2026-03-05 | Lockness  |
+| 1H (annual) | 2026-03-05 | Hiero     |
+| 1H (annual) | 2026-03-12 | Credebl   |
+| 1H (annual) | 2026-03-12 | ToIP      |
+| 1H (annual) | 2026-03-19 | Paladin   |
+| 1H (annual) | 2026-03-19 | Smoot     |
+| 1H (annual) | 2026-03-19 | Minokawa  |
+| 2H          | 2026-07-?? | Cacti     |
+| 2H          | 2026-07-?? | Fabric    |
+| 2H          | 2026-07-?? | Identus   |
+| 2H          | 2026-07-?? | Web3j     |
+| 2H          | 2026-07-?? | Indy      |
+| 2H          | 2026-07-?? | AnonCreds |
+| 2H          | 2026-07-?? | Iroha     |
+| 2H          | 2026-07-?? | Solang    |
+| 2H          | 2026-07-?? | Firefly   |
+| 2H          | 2026-07-?? | Besu      |
+| 2H          | 2026-07-?? | Caliper   |
+| 2H          | 2026-07-?? | Lockness  |
+| 2H          | 2026-07-?? | Hiero     |
+| 2H          | 2026-07-?? | Credebl   |
+| 2H          | 2026-07-?? | ToIP      |
+| 2H          | 2026-07-?? | Paladin   |
+| 2H          | 2026-07-?? | Smoot     |
+| 2H          | 2026-07-?? | Minokawa  |

--- a/tac/project-updates/annual-review-instructions.md
+++ b/tac/project-updates/annual-review-instructions.md
@@ -1,10 +1,13 @@
 [//]: # (SPDX-License-Identifier: CC-BY-4.0)
 
 # Annual Review Instructions
-Create a file in the `tac/project-updates` subdirectory for the current year and name the file `YYYY-annual-Project-Name.md` (e.g., `tac/project-updates/2024/2024-annual-lf-decentralized-trust-amazing.md`). Update the `mkdocs.yml` document in the root directory to include the file in the `nav` section under the appropriate year and quarter. If the year or quarter does not yet exist, please add it to match what you see in the `Project Updates` section.
+
+The main annual review for a project takes place at the beginning of the year, and is based on the project's annual report write-up. An interim report is submitted by projects in the middle of the year.
+
+Create a file in the `tac/project-updates` subdirectory for the current year and name the file `YYYY-annual-Project-Name.md` (e.g., `tac/project-updates/2024/2024-annual-lf-decentralized-trust-amazing.md`). Update the `mkdocs.yml` document in the root directory to include the file in the `nav` section under the appropriate year and either "1H" or "2H" depending on which report it is. If the year or "1H"/"2H" does not yet exist, please add it to match what you see in the `Project Updates` section.
 
 # What Should the Annual Review Contain
-Unlike the quarterly updates, the annual review process will be a "big picture" assessment of the project by reviewing the progress on goals from the prior year and goals for the next year. In addition, the annual review process will include a deep dive into the project health, including contributor and maintainer diversity and adoption metrics, and will include an assessment of the current project lifecycle state. The review will result in a set of recommendations for the project to improve and/or recommendation to move a project to another state.
+Unlike the mid-year updates, the annual review process will be a "big picture" assessment of the project by reviewing the progress on goals from the prior year and goals for the next year. In addition, the annual review process will include a deep dive into the project health, including contributor and maintainer diversity and adoption metrics, and will include an assessment of the current project lifecycle state. The review will result in a set of recommendations for the project to improve and/or recommendation to move a project to another state.
 
 The annual review should answer the following questions:
 

--- a/tac/project-updates/mid-year-update-instructions.md
+++ b/tac/project-updates/mid-year-update-instructions.md
@@ -1,20 +1,25 @@
-[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+[//]: # "SPDX-License-Identifier: CC-BY-4.0"
 
-# Quarterly Review Instructions
-Create a file in the `tac/project-updates` subdirectory for the current year and name the file `YYYY-Qn-Project-Name.md` (e.g., `2023-Q1-Hyperledger-Iroha.md`).  Update the `mkdocs.yml` document in the root directory to include the file in the `nav` section under the appropriate year and quarter. If the year or quarter does not yet exist, please add it to match what you see in the `Project Updates` section.
+# Mid-year Review Instructions
 
-# What Should the Quarterly Review Contain
-Quarterly reviews are intended to look at the past quarter to see how the project is progressing against its goals. The allow for a wide audience to better understand the project's health. 
+Projects are required to create a mid-year report for their project.
 
-The quarterly review should answer the following questions:
+Create a file in the `tac/project-updates` subdirectory for the current year and name the file `YYYY-Qn-Project-Name.md` (e.g., `2023-MidYear-Hyperledger-Iroha.md`). Update the `mkdocs.yml` document in the root directory to include the file in the `nav` section under the appropriate mid-year section e.g. "2026" as the top level, "MidYear" as the level below it. If the year or mid-year nav does not yet exist, please add it to match what you see in the `Project Updates` section.
+
+# What Should the Mid-Year Review Contain?
+
+Mid-year reviews are intended to look at the 6 months since the annual review to see how the project is progressing against its goals. This allows for a wide audience to better understand the project's health.
+
+The review should answer the following questions:
 
 - How are you progressing against your yearly goals?
-- What deliverables/outputs did you have in the past quarter?
-- What are your goals for the next quarter?
+- What deliverables/outputs did you have in the past 6 months?
+- What are your goals for the second half of the year?
 - Do you need any help?
 - Changes to maintainer/contributor diversity
 
 # What Does the TAC Evaluate
+
 In general, the TAC will be looking at the health of the project overall and if it is in the correct lifecycle state. The following is what the TAC will specifically look for:
 
 - Whether all requirements specified in the [LF Decentralized Trust TAC governance documents](../governing-documents/index.md) were met.
@@ -27,6 +32,7 @@ In general, the TAC will be looking at the health of the project overall and if 
 - Understanding how the project has performed against the goals set in the annual review. If you have not achieved the goals that you set out, that is okay. Feel free to include updates to your goals if things have changed. The TAC should look at what has been accomplished and what challenges the project had in meeting the goals. Ensure your roadmap is up-to-date and is publically available.
 
 # What is the Outcome of the Review
+
 The TAC will approve and merge the pull request or request changes be made to the PR prior to approval and merge. In addition, any follow up action items should be captured in the [lf-decentralized-trust/governance] GitHub repo as issues.
 
 [lf-decentralized-trust/governance]: https://github.com/lf-decentralized-trust/governance/


### PR DESCRIPTION
This is a first look at what our governance documents might look like if we move to twice-yearly reports.

I've used the term "Mid-Year" as the name for the non-annual report. Perhaps "Interim" would be better?

~I'll leave in draft for now while we discuss. I haven't actually looked at what the Mid-Year report should entail - so currently it simply reflects what a quarterly report would cover.~ Moved out of draft, and suggesting that Mid-Year reports are expected to contain the same level of detail as a quarterly report currently does.

Perhaps we stage our changes here, and first move to twice yearly, then reflect on how we might evolve the mid-year report contents.