### PR TITLE
Add meeting agenda for 23rd April 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
   - Meetings:
     - meeting-minutes/index.md
     - 2026:
+      - 2026-04-23: meeting-minutes/2026/2026-04-23.md
       - 2026-04-16: meeting-minutes/2026/2026-04-16.md
       - 2026-04-09: meeting-minutes/2026/2026-04-09.md
       - 2026-04-02: meeting-minutes/2026/2026-04-02.md

--- a/tac/meeting-minutes/2026/2026-04-23.md
+++ b/tac/meeting-minutes/2026/2026-04-23.md
@@ -13,9 +13,13 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Annual reports
 - [Web3J Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/294) - Marcus, Kanchan
+  - Approved on roll call vote: six aye, five absent
 - [Lockness Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/298) - Matthew, Hendrik
+  - Approved on roll call vote; nine aye, two absent
 - [Hiero Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/299) - Enrique, Kanchan
+  - Approved on roll call vote; nine aye, two absent
 - [Hyperledger Iroha Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/310) - Rama, Osama
+  - Approved on roll call vote; six aye, five absent
 - [Paladin Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/313) - Rama, Diane
 - [Indy Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/284) - Matthew, Kevin
 - [Besu Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/318) - Yoav, Enrique
@@ -49,14 +53,14 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Attended by
 
-- [ ] Marcus Brandenburger
-- [ ] Hendrik Ebbers
-- [ ] Kanchan Kaur
-- [ ] Kevin Millikin
-- [ ] Enrique Lacal
-- [ ] Diane Mueller
-- [ ] Venkatraman Ramakrishna
-- [ ] Osama Rabea
-- [ ] Arun S M
-- [ ] Yoav Tock
-- [ ] Matthew Whitehead
+- [x] Marcus Brandenburger
+- [x] Hendrik Ebbers
+- [ ] ~~Kanchan Kaur~~
+- [x] Kevin Millikin
+- [x] Enrique Lacal
+- [x] Diane Mueller
+- [x] Venkatraman Ramakrishna
+- [x] Osama Rabea
+- [x] Arun S M
+- [x] Yoav Tock
+- [ ] ~~Matthew Whitehead~~

--- a/tac/meeting-minutes/2026/2026-04-23.md
+++ b/tac/meeting-minutes/2026/2026-04-23.md
@@ -1,0 +1,62 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the LF Decentralized Trust Community](../images/all-are-welcome.png "All are Welcome in the LF Decentralized Trust Community")
+
+Linux Foundation Decentralized Trust is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [LF Decentralized Trust Code of Conduct](../../governing-documents/code-of-conduct.md).
+
+# Meeting Link
+- [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96405933609?password=dc76428e-6a2d-435f-a020-a590bc4b94a4)
+
+# Announcements
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [leave a comment for consideration on the upcoming newsletter wiki page](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/697270275/2026).
+
+# Annual reports
+- [Web3J Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/294) - Marcus, Kanchan
+- [Lockness Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/298) - Matthew, Hendrik
+- [Hiero Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/299) - Enrique, Kanchan
+- [Hyperledger Iroha Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/310) - Rama, Osama
+- [Paladin Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/313) - Rama, Diane
+- [Indy Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/284) - Matthew, Kevin
+- [Besu Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/318) - Yoav, Enrique
+
+# Overdue reports
+- Hyperledger Solang Annual Report (due February 12, 2026)
+- Credebl Annual Report (due March 12, 2026)
+- ToIP Annual Report (due March 12, 2026)
+- Smoot Annual Report (due March 19, 2026)
+- Minokawa Annual Report (due March 19, 2026)
+
+# Upcoming reports
+- [2026 TAC Project Update Calendar](../../project-updates/2026/2026-schedule.md)
+
+# Labs summary
+- [AP3 - Agent Privacy-Preserving Protocol](https://github.com/LF-Decentralized-Trust-labs/LF-Decentralized-Trust-labs.github.io/pull/391)
+- [OptiMesh](https://github.com/LF-Decentralized-Trust-labs/LF-Decentralized-Trust-labs.github.io/pull/389)
+
+# Discussion
+- Project report reviews, find the [TAC member assignment worksheet](https://docs.google.com/spreadsheets/d/1u1yKuu8dl00ie-Nsm1sFJcIF82njYJw0swfEidx5Foo/edit?gid=1376954816#gid=1376954816) for reviews.
+- AI contribution guidelines — Rafael's [governance PR #321](https://github.com/LF-Decentralized-Trust/governance/pull/321).
+- Governance docs update to move from quarterly to twice-yearly reports — Matthew's [governance PR #319](https://github.com/LF-Decentralized-Trust/governance/pull/319).
+- How TAC can actively promote and guide project teams toward SLSA-aligned best practices?
+- Framework for assigning phases/maturity levels to sub‑projects independently (e.g., Fabric vs. Fabric‑X).
+
+# Recordings
+- [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Upcoming meetings
+- [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Hendrik Ebbers
+- [ ] Kanchan Kaur
+- [ ] Kevin Millikin
+- [ ] Enrique Lacal
+- [ ] Diane Mueller
+- [ ] Venkatraman Ramakrishna
+- [ ] Osama Rabea
+- [ ] Arun S M
+- [ ] Yoav Tock
+- [ ] Matthew Whitehead


### PR DESCRIPTION
## Summary
- 7 annual reports in review (Web3J, Lockness, Hiero, Iroha, Paladin, Indy, Besu)
- 5 overdue reports (Solang, Credebl, ToIP, Smoot, Minokawa)
- 2 lab proposals (AP3, OptiMesh)
- Discussion: project report reviews, AI contribution guidelines (PR #321), quarterly to twice-yearly reports (PR #319), SLSA best practices, sub-project maturity framework