### PR TITLE
Add meeting agenda for 7th May 2026

### DIFF
--- a/.github/workflows/report-reminders.yml
+++ b/.github/workflows/report-reminders.yml
@@ -1,7 +1,5 @@
 name: Send project report reminders
 on:
-  schedule:
-    - cron: '0 1 * * *'
   workflow_dispatch:
 permissions:
   issues: write

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
   - Meetings:
     - meeting-minutes/index.md
     - 2026:
+      - 2026-05-07: meeting-minutes/2026/2026-05-07.md
       - 2026-04-30: meeting-minutes/2026/2026-04-30.md
       - 2026-04-23: meeting-minutes/2026/2026-04-23.md
       - 2026-04-16: meeting-minutes/2026/2026-04-16.md

--- a/tac/meeting-minutes/2026/2026-05-07.md
+++ b/tac/meeting-minutes/2026/2026-05-07.md
@@ -47,14 +47,14 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Attended by
 
-- [ ] Marcus Brandenburger
-- [ ] Hendrik Ebbers
-- [ ] Kanchan Kaur
-- [ ] Kevin Millikin
-- [ ] Enrique Lacal
-- [ ] Diane Mueller
-- [ ] Venkatraman Ramakrishna
-- [ ] Osama Rabea
-- [ ] Arun S M
-- [ ] Yoav Tock
-- [ ] Matthew Whitehead
+- [x] Marcus Brandenburger
+- [x] Hendrik Ebbers
+- [ ] ~~Kanchan Kaur~~
+- [ ] ~~Kevin Millikin~~
+- [x] Enrique Lacal
+- [x] Diane Mueller
+- [ ] ~~Venkatraman Ramakrishna~~
+- [ ] ~~Osama Rabea~~
+- [x] Arun S M
+- [ ] ~~Yoav Tock~~
+- [ ] ~~Matthew Whitehead~~

--- a/tac/meeting-minutes/2026/2026-05-07.md
+++ b/tac/meeting-minutes/2026/2026-05-07.md
@@ -1,0 +1,60 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the LF Decentralized Trust Community](../images/all-are-welcome.png "All are Welcome in the LF Decentralized Trust Community")
+
+Linux Foundation Decentralized Trust is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [LF Decentralized Trust Code of Conduct](../../governing-documents/code-of-conduct.md).
+
+# Meeting Link
+- [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96405933609?password=dc76428e-6a2d-435f-a020-a590bc4b94a4)
+
+# Announcements
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [leave a comment for consideration on the upcoming newsletter wiki page](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/697270275/2026).
+- New project proposal under review: [Hyperledger Token SDK](https://github.com/LF-Decentralized-Trust/project-proposals/pull/51) (graduation from Fabric Token SDK lab to incubating).
+
+# Annual reports
+- [Paladin Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/313) - Rama, Diane
+- [Besu Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/318) - Yoav, Enrique
+- [Smoot Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/326) - Hendrik, Marcus
+
+# Overdue reports
+- Hyperledger Solang Annual Report (due February 12, 2026) - extension granted; awaiting Stellar Foundation grant decision, to check back on May 7, 2026
+- ToIP Annual Report (due March 12, 2026) - project team requested help with preparation; Arun assisting
+- Minokawa Annual Report (due March 19, 2026)
+
+# Upcoming reports
+- [2026 TAC Project Update Calendar](../../project-updates/2026/2026-schedule.md)
+
+# Labs summary
+- [OptiMesh](https://github.com/LF-Decentralized-Trust-labs/LF-Decentralized-Trust-labs.github.io/pull/389) - system-agnostic, multi-pair optimization architecture that jointly optimizes execution and liquidity participation within a unified feasibility framework
+- [Rethv](https://github.com/LF-Decentralized-Trust-labs/LF-Decentralized-Trust-labs.github.io/pull/393) - experimental fork of Reth that replaces the Ethereum Virtual Machine execution with a RISC-V virtual machine
+
+# Discussion
+- Lab proposals review.
+- DCO and contribution mechanisms — see [DCO rationale](https://bestpractices.linuxfoundation.org/ip/contribution-mechanisms-dco.html) and [contribution mechanisms](https://bestpractices.linuxfoundation.org/ip/contribution-mechanisms.html); requested by Besu and Hiero.
+- Governance docs update to move from quarterly to twice-yearly reports — Matthew's [governance PR #319](https://github.com/LF-Decentralized-Trust/governance/pull/319).
+- ADOPTERS.md going forward — several maintainers decline to maintain the file.
+- Project report reviews, find the [TAC member assignment worksheet](https://docs.google.com/spreadsheets/d/1u1yKuu8dl00ie-Nsm1sFJcIF82njYJw0swfEidx5Foo/edit?gid=1376954816#gid=1376954816) for reviews.
+- AI contribution guidelines — Rafael's [governance PR #321](https://github.com/LF-Decentralized-Trust/governance/pull/321).
+- How TAC can actively promote and guide project teams toward SLSA-aligned best practices?
+- Framework for assigning phases/maturity levels to sub‑projects independently (e.g., Fabric vs. Fabric‑X).
+
+# Recordings
+- [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Upcoming meetings
+- [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Hendrik Ebbers
+- [ ] Kanchan Kaur
+- [ ] Kevin Millikin
+- [ ] Enrique Lacal
+- [ ] Diane Mueller
+- [ ] Venkatraman Ramakrishna
+- [ ] Osama Rabea
+- [ ] Arun S M
+- [ ] Yoav Tock
+- [ ] Matthew Whitehead


### PR DESCRIPTION
## Summary
- Adds the TAC meeting agenda for 7th May 2026
- Updates `mkdocs.yml` to include the new agenda in navigation
- Annual reports in progress: Paladin, Besu, Smoot
- Overdue reports: Solang, ToIP, Minokawa
- Open lab proposals: OptiMesh, Rethv
- Discussion topics include lab proposals review, DCO and contribution mechanisms (requested by Besu and Hiero), twice-yearly reports governance update, ADOPTERS.md going forward, project report reviews, AI contribution guidelines, SLSA-aligned best practices, and sub-project maturity framework