### PR TITLE
Add meeting agenda for 21st May 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
   - Meetings:
     - meeting-minutes/index.md
     - 2026:
+      - 2026-05-21: meeting-minutes/2026/2026-05-21.md
       - 2026-05-14: meeting-minutes/2026/2026-05-14.md
       - 2026-05-07: meeting-minutes/2026/2026-05-07.md
       - 2026-04-30: meeting-minutes/2026/2026-04-30.md

--- a/tac/meeting-minutes/2026/2026-05-21.md
+++ b/tac/meeting-minutes/2026/2026-05-21.md
@@ -33,6 +33,8 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 # Discussion
 - Lab proposals review.
 - Project report reviews, find the [TAC member assignment worksheet](https://docs.google.com/spreadsheets/d/1u1yKuu8dl00ie-Nsm1sFJcIF82njYJw0swfEidx5Foo/edit?gid=1376954816#gid=1376954816) for reviews.
+- Presentation on [Hyperledger Token SDK](https://github.com/LF-Decentralized-Trust/project-proposals/pull/51)
+  - Presentation by [Angelo De Caro](https://github.com/adecaro)
 - ADOPTERS.md going forward — cross-referencing project ADOPTERS.md files with the use case tracker (350 entries today); follow-up on progress and read-only access for maintainers.
 - Mid-year report template and expectations under the new twice-yearly cadence (governance PR #319 merged on May 8, 2026).
 - AI contribution guidelines — Rafael's [governance PR #321](https://github.com/LF-Decentralized-Trust/governance/pull/321); proposal to split into mandatory vs suggested guidance ahead of merging.

--- a/tac/meeting-minutes/2026/2026-05-21.md
+++ b/tac/meeting-minutes/2026/2026-05-21.md
@@ -1,0 +1,62 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the LF Decentralized Trust Community](../images/all-are-welcome.png "All are Welcome in the LF Decentralized Trust Community")
+
+Linux Foundation Decentralized Trust is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [LF Decentralized Trust Code of Conduct](../../governing-documents/code-of-conduct.md).
+
+# Meeting Link
+- [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96405933609?password=dc76428e-6a2d-435f-a020-a590bc4b94a4)
+
+# Announcements
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [leave a comment for consideration on the upcoming newsletter wiki page](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/697270275/2026).
+- New project proposal under review: [Hyperledger Token SDK](https://github.com/LF-Decentralized-Trust/project-proposals/pull/51) (graduation from Fabric Token SDK lab to incubating).
+- Learn about the new Lineth project, the open source code that powers the public Linea Mainnet network, at the Inside the Production-Grade ZK Rollup Stack workshop on June 10 at 9am Eastern. To Register: https://zoom.us/meeting/register/dBWDdu0oSZCRJRXCDae1qQ
+- TAC mid-year retrospection is open for anonymous feedback. TAC members are requested to share what is working well and what can be improved for the rest of 2026: https://retrotool.io/BYYlkqSEySlENjM6c2pXd
+
+# Annual reports
+- [Paladin Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/313) - Rama, Diane
+- [Besu Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/318) - Yoav, Enrique
+- [Smoot Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/326) - Hendrik, Marcus
+
+# Overdue reports
+- Hyperledger Solang Annual Report (due February 12, 2026) - extension granted; awaiting Stellar Foundation grant decision
+- ToIP Annual Report (due March 12, 2026) - project team requested help with preparation; Arun assisting
+- Minokawa Annual Report (due March 19, 2026) - project team working on it
+
+# Upcoming reports
+- [2026 TAC Project Update Calendar](../../project-updates/2026/2026-schedule.md)
+
+# Labs summary
+- [Veltora Core](https://github.com/LF-Decentralized-Trust-labs/LF-Decentralized-Trust-labs.github.io/pull/389) - system-agnostic, multi-pair optimization architecture that jointly optimizes execution and liquidity participation within a unified feasibility framework (proposal renamed from OptiMesh)
+
+# Discussion
+- Lab proposals review.
+- Project report reviews, find the [TAC member assignment worksheet](https://docs.google.com/spreadsheets/d/1u1yKuu8dl00ie-Nsm1sFJcIF82njYJw0swfEidx5Foo/edit?gid=1376954816#gid=1376954816) for reviews.
+- ADOPTERS.md going forward — cross-referencing project ADOPTERS.md files with the use case tracker (350 entries today); follow-up on progress and read-only access for maintainers.
+- Mid-year report template and expectations under the new twice-yearly cadence (governance PR #319 merged on May 8, 2026).
+- AI contribution guidelines — Rafael's [governance PR #321](https://github.com/LF-Decentralized-Trust/governance/pull/321); proposal to split into mandatory vs suggested guidance ahead of merging.
+- DCO mechanical friction — document common sign-off issues (browser/IDE mismatches) and resolutions alongside the [LF legal team's guidance page](https://lfprojects.org/policies/dco/).
+- Documenting labs policy (approval-by-absence-of-objection, historical rejection rationale) for new TAC members.
+- How TAC can actively promote and guide project teams toward SLSA-aligned best practices?
+- Framework for assigning phases/maturity levels to sub‑projects independently (e.g., Fabric vs. Fabric‑X).
+
+# Recordings
+- [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Upcoming meetings
+- [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Hendrik Ebbers
+- [ ] Kanchan Kaur
+- [ ] Kevin Millikin
+- [ ] Enrique Lacal
+- [ ] Diane Mueller
+- [ ] Venkatraman Ramakrishna
+- [ ] Osama Rabea
+- [ ] Arun S M
+- [ ] Yoav Tock
+- [ ] Matthew Whitehead

--- a/tac/meeting-minutes/2026/2026-05-21.md
+++ b/tac/meeting-minutes/2026/2026-05-21.md
@@ -49,14 +49,14 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Attended by
 
-- [ ] Marcus Brandenburger
-- [ ] Hendrik Ebbers
-- [ ] Kanchan Kaur
-- [ ] Kevin Millikin
-- [ ] Enrique Lacal
-- [ ] Diane Mueller
-- [ ] Venkatraman Ramakrishna
-- [ ] Osama Rabea
-- [ ] Arun S M
-- [ ] Yoav Tock
-- [ ] Matthew Whitehead
+- [x] Marcus Brandenburger
+- [x] Hendrik Ebbers
+- [ ] ~~Kanchan Kaur~~
+- [x] Kevin Millikin
+- [x] Enrique Lacal
+- [x] Diane Mueller
+- [x] Venkatraman Ramakrishna
+- [x] Osama Rabea
+- [x] Arun S M
+- [ ] ~~Yoav Tock~~
+- [x] Matthew Whitehead


### PR DESCRIPTION
## Summary

Adds the TAC meeting agenda for **21 May 2026**.

### Annual reports up for review
- Paladin (PR #313) — Rama, Diane
- Besu (PR #318) — Yoav, Enrique
- Smoot (PR #326) — Hendrik, Marcus

### Overdue
- Solang — extension granted; awaiting Stellar Foundation grant decision
- ToIP — Arun assisting
- Minokawa — project team working on it

### Lab updates
- Veltora Core (PR #389) — system-agnostic, multi-pair optimization architecture (formerly OptiMesh)

### Discussion topics carried forward
- Lab proposals review
- Project report reviews — TAC member assignment worksheet
- ADOPTERS.md going forward — cross-referencing with the use case tracker
- Mid-year report template and expectations (new twice-yearly cadence — governance PR #319 merged)
- AI contribution guidelines (PR #321) — proposal to split into mandatory vs suggested
- DCO mechanical friction — document common sign-off issues and resolutions
- Documenting labs policy for new TAC members
- SLSA-aligned best practices guidance
- Phases/maturity per sub-project framework

Also updates `mkdocs.yml` nav.
