### PR TITLE
Remove Zoom meeting link from index.md

### DIFF
--- a/tac/meeting-minutes/index.md
+++ b/tac/meeting-minutes/index.md
@@ -5,9 +5,5 @@
 ## Upcoming meetings
 - [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
 
-## Meeting Link
-- [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/95530440160?password=6e6b9a15-a635-497e-a6ce-078e6b1d2b49)
-
 ## Recordings
 - [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
-


### PR DESCRIPTION
Removed the Zoom meeting link from the meeting minutes.