### PR TITLE
Add meeting agenda for 25th June 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
   - Meetings:
       - meeting-minutes/index.md
       - 2026:
+          - 2026-06-25: meeting-minutes/2026/2026-06-25.md
           - 2026-06-18: meeting-minutes/2026/2026-06-18.md
           - 2026-06-11: meeting-minutes/2026/2026-06-11.md
           - 2026-06-04: meeting-minutes/2026/2026-06-04.md

--- a/tac/meeting-minutes/2026/2026-06-25.md
+++ b/tac/meeting-minutes/2026/2026-06-25.md
@@ -1,0 +1,59 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the LF Decentralized Trust Community](../images/all-are-welcome.png "All are Welcome in the LF Decentralized Trust Community")
+
+Linux Foundation Decentralized Trust is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [LF Decentralized Trust Code of Conduct](../../governing-documents/code-of-conduct.md).
+
+# Meeting Link
+- [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96405933609?password=dc76428e-6a2d-435f-a020-a590bc4b94a4)
+
+# Announcements
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [leave a comment for consideration on the upcoming newsletter wiki page](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/697270275/2026).
+- On July 8, 2026, the Lineth Lab team will have a followup technical deep dive workshop. Register here: https://zoom.us/meeting/register/bvi8sJKQTeWy2JzY6lEUfg
+
+# Annual reports
+- [Smoot Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/326) - Hendrik, Marcus
+- [ToIP Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/332) - Diane, Yoav
+
+# Overdue reports
+- Minokawa Annual Report (due March 19, 2026) - project team working on it
+
+# Upcoming reports
+- [2026 TAC Project Update Calendar](../../project-updates/2026/2026-schedule.md)
+
+# Discussion
+- Project report reviews, find the [TAC member assignment worksheet](https://docs.google.com/spreadsheets/d/1u1yKuu8dl00ie-Nsm1sFJcIF82njYJw0swfEidx5Foo/edit?gid=1376954816#gid=1376954816) for reviews.
+- [Waterfall Network](https://github.com/LF-Decentralized-Trust/project-proposals/pull/52) proposal.
+- Mid-year report template and expectations under the new twice-yearly cadence (governance PR #319 merged on May 8, 2026).
+
+# Pending Discussion
+- AI contribution guidelines — Rafael's [governance PR #321](https://github.com/LF-Decentralized-Trust/governance/pull/321); Hendrik and Diane to share feedback collected from the Hiero TSC community.
+- ADOPTERS.md going forward — cross-referencing project ADOPTERS.md files with the use case tracker (350 entries today); follow-up on progress and read-only access for maintainers.
+- DCO mechanical friction — document common sign-off issues (browser/IDE mismatches) and resolutions alongside the [LF legal team's guidance page](https://lfprojects.org/policies/dco/).
+- Documenting labs policy (approval-by-absence-of-objection, historical rejection rationale) for new TAC members.
+- How TAC can actively promote and guide project teams toward SLSA-aligned best practices?
+- Framework for assigning phases/maturity levels to sub‑projects independently (e.g., Fabric vs. Fabric‑X).
+- Proposal for an AI working group within LF Decentralized Trust, with alignment to the LF Agentic AI sub-foundation (Hendrik).
+- TAC proposals communication process.
+- [Discussion on project charters for LFDT Labs](https://docs.google.com/document/d/1uremzk7OkM4fRZXlVnE11wI3UeGrBv7iw4ijuB16Xqw/edit?tab=t.0).
+
+# Recordings
+- [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Upcoming meetings
+- [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Hendrik Ebbers
+- [ ] Kanchan Kaur
+- [ ] Kevin Millikin
+- [ ] Enrique Lacal
+- [ ] Diane Mueller
+- [ ] Venkatraman Ramakrishna
+- [ ] Osama Rabea
+- [ ] Arun S M
+- [ ] Yoav Tock
+- [ ] Matthew Whitehead

--- a/tac/meeting-minutes/2026/2026-06-25.md
+++ b/tac/meeting-minutes/2026/2026-06-25.md
@@ -46,14 +46,14 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Attended by
 
-- [ ] Marcus Brandenburger
-- [ ] Hendrik Ebbers
-- [ ] Kanchan Kaur
-- [ ] Kevin Millikin
-- [ ] Enrique Lacal
-- [ ] Diane Mueller
-- [ ] Venkatraman Ramakrishna
-- [ ] Osama Rabea
-- [ ] Arun S M
-- [ ] Yoav Tock
-- [ ] Matthew Whitehead
+- [ ] ~~Marcus Brandenburger~~
+- [ ] ~~Hendrik Ebbers~~
+- [ ] ~~Kanchan Kaur~~
+- [ ] ~~Kevin Millikin~~
+- [ ] ~~Enrique Lacal~~
+- [x] Diane Mueller
+- [ ] ~~Venkatraman Ramakrishna~~
+- [x] Osama Rabea
+- [x] Arun S M
+- [x] Yoav Tock
+- [ ] ~~Matthew Whitehead~~


### PR DESCRIPTION
## Summary

Adds the TAC meeting agenda for **25 June 2026**.

### Annual reports up for review
- Smoot (PR #326) — Hendrik, Marcus
- ToIP (PR #332) — Diane, Yoav

### Overdue
- Minokawa — project team working on it (due March 19, 2026)

### Discussion topics carried forward
- Waterfall Network proposal
- Mid-year report template and expectations under the new twice-yearly cadence
- AI contribution guidelines
- ADOPTERS.md going forward
- DCO mechanical friction
- Documenting labs policy
- SLSA best practices guidance
- Sub-project maturity framework
- AI working group proposal
- TAC proposals communication process
- Project charters for LFDT Labs

Also updates `mkdocs.yml` nav.
