### PR TITLE
Add 2025 Annual Report for Trust Over IP Foundation

### DIFF
--- a/tac/project-updates/2026/2026-annual-ToIP.md
+++ b/tac/project-updates/2026/2026-annual-ToIP.md
@@ -1,0 +1,278 @@
+# **Trust Over IP Foundation 2025 Annual Report**
+
+
+### **Executive Summary**
+
+The Trust Over IP Foundation remained active throughout 2025 and continued to advance its mission through standards development, ecosystem governance, trust registry work, technical architecture activities, and the launch of new initiatives focused on AI trust and decentralized trust relationships.
+
+In addition to ongoing working group activities, several specifications advanced through public review and publication milestones while new working groups were established to address emerging trust challenges.
+
+**Supporting References**
+
+* Trust Over IP Foundation: [https://trustoverip.org/](https://trustoverip.org/)  
+* LFDT Project Page: [https://www.lfdecentralizedtrust.org/projects/trust-over-ip](https://www.lfdecentralizedtrust.org/projects/trust-over-ip)  
+* Deliverables Catalog: [https://trustoverip.org/our-work/deliverables/](https://trustoverip.org/our-work/deliverables/)
+
+---
+
+## **Technology Architecture Activities**
+
+The Technology Architecture Working Group continued development and maintenance of the Trust Over IP Architecture and related technical standards.
+
+### **Evidence of Activity**
+
+* Ongoing maintenance and refinement of the Technology Architecture Specification. 
+* Refinement of the Trust Spanning Protocol v1.0 Implementers Draft specification. 
+* Continued support for interoperability, trust registries, governance frameworks, and Trust Spanning Protocol initiatives.
+
+**Supporting References**
+
+* Technology Architecture Specification: [https://trustoverip.github.io/TechArch/](https://trustoverip.github.io/TechArch/)  
+* Technology Architecture Overview: [https://trustoverip.org/our-work/technical-architecture/](https://trustoverip.org/our-work/technical-architecture/)
+---
+
+## **Governance Framework Adoption and Ecosystem Impact**
+
+The Governance Architecture Specification and Governance Metamodel continued to serve as foundational components of the ToIP governance stack during 2025\.
+
+While no new versions of these specifications were formally released during the reporting period, the frameworks continued to be applied and referenced within digital trust initiatives and conformance programs.
+
+### **Evidence of Impact**
+
+* Continued use of the Governance Metamodel as a reference framework for digital trust ecosystem governance.  
+* Application of ToIP governance concepts within the C2PA Conformance Program.  
+* Continued use of governance frameworks in trust registry and trust ecosystem design discussions.
+
+**Supporting References**
+
+* Governance Architecture Specification: [https://trustoverip.org/news/2022/02/01/the-toip-foundation-releases-its-first-official-governance-specifications/](https://trustoverip.org/news/2022/02/01/the-toip-foundation-releases-its-first-official-governance-specifications/)  
+* Governance Metamodel Specification: [https://trustoverip.org/news/2022/02/01/the-toip-foundation-releases-its-first-official-governance-specifications/](https://trustoverip.org/news/2022/02/01/the-toip-foundation-releases-its-first-official-governance-specifications/)  
+* C2PA Conformance Program Presentation: [https://trustoverip.org/blog/2025/05/20/egwg-2025-05-15-the-c2pa-conformance-program-scott-perry/](https://trustoverip.org/blog/2025/05/20/egwg-2025-05-15-the-c2pa-conformance-program-scott-perry/)  
+* ToIP Glossary: [https://glossary.trustoverip.org/](https://glossary.trustoverip.org/)
+
+---
+
+## **Trust Registry Activities**
+
+The Trust Registry Working Group continued advancing standards and protocols supporting interoperable trust registries.
+
+### **Evidence of Progress**
+
+A significant milestone during the reporting period was advancement of the Trust Registry Query Protocol (TRQP) Version 2.0 specification through public review and toward formal publication.
+
+* Public Review 02 announced during 2025\.  
+* Version 2.0 formally approved by the ToIP Steering Committee as a ToIP Approved Deliverable and published in April 2026\.
+
+**Supporting References**
+
+* Trust Registry Query Protocol (TRQP) v2.0 Specification: [https://trustoverip.github.io/tswg-trust-registry-protocol/](https://trustoverip.github.io/tswg-trust-registry-protocol/)  
+* TRQP Public Review 02 Announcement: [https://www.lfdecentralizedtrust.org/blog/toip-announces-public-review-02-of-the-trust-registry-query-protocol-trqp-specification-v2.0](https://www.lfdecentralizedtrust.org/blog/toip-announces-public-review-02-of-the-trust-registry-query-protocol-trqp-specification-v2.0)  
+* Deliverables Catalog: [https://trustoverip.org/our-work/deliverables/](https://trustoverip.org/our-work/deliverables/)
+
+---
+
+## **KERI, ACDC, and CESR Specification Advancement**
+
+Foundation contributors continued advancing the Key Event Receipt Infrastructure (KERI), Authentic Chained Data Containers (ACDC), and Composable Event Streaming Representation (CESR) specifications.
+
+### **Evidence of Progress**
+
+Work completed during 2025 resulted in publication of Version 1.1 releases in January 2026\.
+
+#### **KERI Specification Version 1.1**
+
+Version 1.1 of the KERI specification was published in January 2026\.
+
+**Supporting References**
+
+* KERI Repository and Specification: [https://github.com/WebOfTrust/keri](https://github.com/WebOfTrust/keri)  
+* Deliverables Catalog: [https://trustoverip.org/our-work/deliverables/](https://trustoverip.org/our-work/deliverables/)
+
+#### **ACDC Specification Version 1.1**
+
+Version 1.1 of the ACDC specification was published in January 2026\.
+
+**Supporting References**
+
+* ACDC Repository and Specification: [https://github.com/WebOfTrust/acdc](https://github.com/WebOfTrust/acdc)  
+* Deliverables Catalog: [https://trustoverip.org/our-work/deliverables/](https://trustoverip.org/our-work/deliverables/)
+
+#### **CESR Specification Version 1.1**
+
+Version 1.1 of the CESR specification was published in January 2026\.
+
+**Supporting References**
+
+* CESR Repository and Specification: [https://github.com/WebOfTrust/cesr](https://github.com/WebOfTrust/cesr)  
+* Deliverables Catalog: [https://trustoverip.org/our-work/deliverables/](https://trustoverip.org/our-work/deliverables/)
+
+---
+
+## **Trust Spanning Protocol Activities**
+
+Work continued around Trust Spanning Protocol concepts and interoperability mechanisms intended to support trust relationships across organizational and ecosystem boundaries.
+
+### **Evidence of Activity**
+
+* Continued development of Trust Spanning Protocol concepts.  
+* Alignment with trust registry, governance, and interoperability initiatives.  
+* Foundation for emerging AI trust and agent trust discussions.
+
+**Supporting References**
+
+* Deliverables Catalog: [https://trustoverip.org/our-work/deliverables/](https://trustoverip.org/our-work/deliverables/)  
+* Trust Spanning Protocol Specification: (https://trustoverip.github.io/tswg-tsp-specification)[https://trustoverip.github.io/tswg-tsp-specification]
+
+---
+
+## **AI & Human Trust Working Group**
+
+The AI & Human Trust Working Group was launched during 2025 to explore how digital trust infrastructure, governance frameworks, identity systems, and interoperability standards can support trustworthy interactions between humans and AI systems.
+
+### **Evidence of Progress**
+
+* New working group established during 2025\.  
+* Community participation initiated.  
+* Initial scope and work program defined.  
+* Future deliverable pipeline established.
+
+**Supporting References**
+
+* Working Group Announcement: [https://www.lfdecentralizedtrust.org/blog/toip-and-dif-announce-three-new-working-groups-for-trust-in-the-age-of-ai](https://www.lfdecentralizedtrust.org/blog/toip-and-dif-announce-three-new-working-groups-for-trust-in-the-age-of-ai)
+
+---
+
+## **Decentralized Trust Graph Working Group**
+
+The Decentralized Trust Graph Working Group was launched during 2025 to explore decentralized trust relationships, verifiable relationship credentials, proof-of-personhood concepts, and trust graph interoperability.
+
+### **Evidence of Progress**
+
+* New working group established during 2025\.  
+* Scope and objectives defined.  
+* Community participation initiated.  
+* 37 attendees participated in the initial kickoff meetings.
+* 5 initial Task Forces established: Risk Assessment and Harms Prevention, Credentials, Trust Tasks, R-Cards, and Agent Names.
+
+**Supporting References**
+
+* Working Group Announcement: [https://www.lfdecentralizedtrust.org/blog/toip-and-dif-announce-three-new-working-groups-for-trust-in-the-age-of-ai](https://www.lfdecentralizedtrust.org/blog/toip-and-dif-announce-three-new-working-groups-for-trust-in-the-age-of-ai)  
+* Working Group Wiki: [https://lf-toip.atlassian.net/wiki/spaces/HOME/pages/257785857/Decentralized+Trust+Graph+Working+Group](https://lf-toip.atlassian.net/wiki/spaces/HOME/pages/257785857/Decentralized+Trust+Graph+Working+Group)  
+* ToIP Steering Committee Agenda Planning document: [https://docs.google.com/document/d/19M6gHwhtxDR7\_MQKsYlHjbAoFcQS9UdQVWbp24UzosM/edit?pli=1\&tab=t.0](https://docs.google.com/document/d/19M6gHwhtxDR7_MQKsYlHjbAoFcQS9UdQVWbp24UzosM/edit?pli=1&tab=t.0)
+
+---
+
+## **Publications and Deliverables**
+
+### **Deliverables Reaching Formal Release Milestones**
+
+#### **Trust Registry Query Protocol (TRQP) Version 2.0**
+
+The Trust Registry Query Protocol advanced through Public Review 02 during 2025 and was formally published as Version 2.0 in 2026\.
+
+**References**
+
+* Specification: [https://trustoverip.github.io/tswg-trust-registry-protocol/](https://trustoverip.github.io/tswg-trust-registry-protocol/)  
+* Public Review Announcement: [https://www.lfdecentralizedtrust.org/blog/toip-announces-public-review-02-of-the-trust-registry-query-protocol-trqp-specification-v2.0](https://www.lfdecentralizedtrust.org/blog/toip-announces-public-review-02-of-the-trust-registry-query-protocol-trqp-specification-v2.0)
+
+#### **Key Event Receipt Infrastructure (KERI) Version 1.1**
+
+**References**
+
+* Specification Repository: [https://github.com/WebOfTrust/keri](https://github.com/WebOfTrust/keri)
+
+#### **Authentic Chained Data Containers (ACDC) Version 1.1**
+
+**References**
+
+* Specification Repository: [https://github.com/WebOfTrust/acdc](https://github.com/WebOfTrust/acdc)
+
+#### **Composable Event Streaming Representation (CESR) Version 1.1**
+
+**References**
+
+* Specification Repository: [https://github.com/WebOfTrust/cesr](https://github.com/WebOfTrust/cesr)
+
+### **Deliverables Demonstrating Ecosystem Adoption**
+
+#### **Governance Metamodel Usage within C2PA**
+
+The C2PA Conformance Program demonstrated practical application of ToIP governance concepts and governance metamodel principles within a production-oriented ecosystem governance initiative.
+
+**References**
+
+* C2PA Conformance Program Presentation: [https://trustoverip.org/blog/2025/05/20/egwg-2025-05-15-the-c2pa-conformance-program-scott-perry/](https://trustoverip.org/blog/2025/05/20/egwg-2025-05-15-the-c2pa-conformance-program-scott-perry/)
+
+### **New Deliverable Pipelines Established**
+
+* AI & Human Trust Working Group  
+* Decentralized Trust Graph Working Group  
+* Trust Spanning Protocol-related AI trust initiatives
+
+---
+
+## **Community Participation**
+
+The Trust Over IP Foundation continued to operate through an active community of Steering Committee members, Working Groups, Task Forces, partner organizations, and ecosystem collaborators.
+
+### **Community Participation Highlights**
+
+#### **Governance Participation**
+
+* 16 elected Steering Committee members served during the reporting period.
+
+#### **Event Participation**
+
+* 37 attendees participated in the Decentralized Trust Graph Working Group kickoff.  
+* 120+ attendees participated in the SEDI Summit.  
+* 60+ attendees participated in KERIConf.
+
+#### **Working Group Growth**
+
+* AI & Human Trust Working Group launched in 2025\.  
+* Decentralized Trust Graph Working Group launched in 2025\.  
+* SAID URN Task Force approved in 2025\.
+
+#### **Ecosystem Collaboration**
+
+The Foundation maintained active collaboration with:
+
+* Decentralized Identity Foundation (DIF)  
+* C2PA and CAWG initiatives  
+* SEDI (State-Endorsed Digital Identity)  
+* First Person Project  
+* OpenVTC and related trust infrastructure initiatives
+
+### **Source**
+
+The participation metrics above are drawn from the ToIP Steering Committee Agenda Planning document:
+
+[https://docs.google.com/document/d/19M6gHwhtxDR7\_MQKsYlHjbAoFcQS9UdQVWbp24UzosM/edit?pli=1\&tab=t.0](https://docs.google.com/document/d/19M6gHwhtxDR7_MQKsYlHjbAoFcQS9UdQVWbp24UzosM/edit?pli=1&tab=t.0)
+
+### **Additional Metrics That Would Strengthen Future Reports**
+
+* Active contributors by Working Group  
+* Participating organizations by Working Group  
+* Average meeting attendance  
+* New contributors onboarded  
+* Contributor retention  
+* New member organizations joining during the year  
+* Number of specification reviewers  
+* Public review participation statistics  
+* Implementation and adoption metrics
+
+---
+
+**Ecosystem Impact**
+
+The Foundation's standards and architectural work continued influencing digital identity, governance, trust registries, interoperability, and decentralized trust initiatives across multiple ecosystems.
+
+Future annual reports could further strengthen visibility into ecosystem impact by including adoption metrics, implementation examples, specification maturity indicators, and links to supporting reports, presentations, dashboards, and implementation case studies.
+
+### **Suggested Metrics**
+
+* Implementations using ToIP specifications  
+* Organizations adopting governance frameworks  
+* Trust registries deployed  
+* External projects referencing ToIP standards  
+* Conference presentations and ecosystem collaborations


### PR DESCRIPTION
This commit introduces the 2025 Annual Report for the Trust Over IP Foundation, detailing activities, achievements, and community participation throughout the year. It includes sections on technology architecture, governance frameworks, trust registry activities, and new working groups established.