### PR TITLE
Add meeting agenda for 6th August 2026

### DIFF
--- a/.github/configs/project-report-reminders.yml
+++ b/.github/configs/project-report-reminders.yml
@@ -13,7 +13,7 @@ projects:
         description: Please submit the 2026 mid-year report (due 2026-08-27). See the [mid-year review instructions](https://lf-decentralized-trust.github.io/governance/project-updates/mid-year-update-instructions/) for guidance. After submitting your pull request, please mark this issue as complete.
   - name: Hyperledger Fabric
     github_org: hyperledger
-    github_repo: fabric
+    github_repo: fabric-x
     maintainers: []
     schedules:
       - date: 2026-01-22
@@ -63,9 +63,9 @@ projects:
       - date: 2026-01-22
         title: Reminder to submit the 2026 annual project report
         description: Please submit the 2026 annual report (due 2026-01-22). After submitting your pull request, please mark this issue as complete.
-      - date: 2026-07-30
+      - date: 2026-08-13
         title: Reminder to submit the 2026 mid-year project report
-        description: Please submit the 2026 mid-year report (due 2026-07-30). See the [mid-year review instructions](https://lf-decentralized-trust.github.io/governance/project-updates/mid-year-update-instructions/) for guidance. After submitting your pull request, please mark this issue as complete.
+        description: Please submit the 2026 mid-year report (due 2026-08-13). See the [mid-year review instructions](https://lf-decentralized-trust.github.io/governance/project-updates/mid-year-update-instructions/) for guidance. After submitting your pull request, please mark this issue as complete.
   - name: Hyperledger Caliper
     github_org: hyperledger-caliper
     github_repo: governance
@@ -151,9 +151,9 @@ projects:
       - date: 2026-03-12
         title: Reminder to submit the 2026 annual project report
         description: Please submit the 2026 annual report (due 2026-03-12). After submitting your pull request, please mark this issue as complete.
-      - date: 2026-09-10
+      - date: 2026-10-29
         title: Reminder to submit the 2026 mid-year project report
-        description: Please submit the 2026 mid-year report (due 2026-09-10). See the [mid-year review instructions](https://lf-decentralized-trust.github.io/governance/project-updates/mid-year-update-instructions/) for guidance. After submitting your pull request, please mark this issue as complete.
+        description: Please submit the 2026 mid-year report (due 2026-10-29). See the [mid-year review instructions](https://lf-decentralized-trust.github.io/governance/project-updates/mid-year-update-instructions/) for guidance. After submitting your pull request, please mark this issue as complete.
   - name: Web3j
     github_org: LFDT-web3j
     github_repo: governance

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
   - Meetings:
       - meeting-minutes/index.md
       - 2026:
+          - 2026-08-06: meeting-minutes/2026/2026-08-06.md
           - 2026-07-30: meeting-minutes/2026/2026-07-30.md
           - 2026-07-23: meeting-minutes/2026/2026-07-23.md
           - 2026-07-16: meeting-minutes/2026/2026-07-16.md

--- a/tac/meeting-minutes/2026/2026-08-06.md
+++ b/tac/meeting-minutes/2026/2026-08-06.md
@@ -1,0 +1,54 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the LF Decentralized Trust Community](../images/all-are-welcome.png "All are Welcome in the LF Decentralized Trust Community")
+
+Linux Foundation Decentralized Trust is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [LF Decentralized Trust Code of Conduct](../../governing-documents/code-of-conduct.md).
+
+# Meeting Link
+- [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96405933609?password=dc76428e-6a2d-435f-a020-a590bc4b94a4)
+
+# Announcements
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [leave a comment for consideration on the upcoming newsletter wiki page](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/697270275/2026).
+
+# Annual reports
+- [Smoot Annual Review](https://github.com/LF-Decentralized-Trust/governance/pull/326) - Hendrik, Marcus
+
+# Overdue reports
+- Minokawa Annual Report (due March 19, 2026) - 2-week extension granted at Jul 23 meeting; due Aug 6, 2026
+- Cacti Mid-Year Report (due July 30, 2026) - 2-week extension granted; due August 13, 2026
+- Fabric Mid-Year Report (due July 30, 2026) - no PR submitted
+
+# Upcoming reports
+- [2026 TAC Project Update Calendar](../../project-updates/2026/2026-schedule.md)
+- Identus mid-year report due August 6, 2026
+- Web3j mid-year report due August 6, 2026
+- AnonCreds mid-year report due August 13, 2026
+- Indy mid-year report due August 13, 2026
+
+# Labs summary
+- [DAS Interoperability Lab](https://github.com/LF-Decentralized-Trust-labs/LF-Decentralized-Trust-labs.github.io/pull/423) - neutral, open-source standards and pilot body for digital asset securities interoperability specifications and proofs-of-concept on institutional infrastructure
+- [FabricOps](https://github.com/LF-Decentralized-Trust-labs/LF-Decentralized-Trust-labs.github.io/pull/424) - Kubernetes operator for provisioning multi-organisation Hyperledger Fabric networks from declarative configuration
+
+# Discussion
+- AI contribution guidelines — [governance PR #321](https://github.com/LF-Decentralized-Trust/governance/pull/321).
+
+# Recordings
+- [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Upcoming meetings
+- [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Hendrik Ebbers
+- [ ] Kanchan Kaur
+- [ ] Kevin Millikin
+- [ ] Enrique Lacal
+- [ ] Diane Mueller
+- [ ] Venkatraman Ramakrishna
+- [ ] Osama Rabea
+- [ ] Arun S M
+- [ ] Yoav Tock
+- [ ] Matthew Whitehead

--- a/tac/meeting-minutes/2026/2026-08-06.md
+++ b/tac/meeting-minutes/2026/2026-08-06.md
@@ -42,13 +42,13 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 # Attended by
 
 - [ ] Marcus Brandenburger
-- [ ] Hendrik Ebbers
-- [ ] Kanchan Kaur
-- [ ] Kevin Millikin
-- [ ] Enrique Lacal
-- [ ] Diane Mueller
-- [ ] Venkatraman Ramakrishna
-- [ ] Osama Rabea
-- [ ] Arun S M
-- [ ] Yoav Tock
-- [ ] Matthew Whitehead
+- [ ] ~~Hendrik Ebbers~~
+- [ ] ~~Kanchan Kaur~~
+- [ ] ~~Kevin Millikin~~
+- [x] Enrique Lacal
+- [x] Diane Mueller
+- [ ] ~~Venkatraman Ramakrishna~~
+- [ ] ~~Osama Rabea~~
+- [x] Arun S M
+- [x] Yoav Tock
+- [ ] ~~Matthew Whitehead~~

--- a/tac/project-updates/2026/2026-schedule.md
+++ b/tac/project-updates/2026/2026-schedule.md
@@ -23,7 +23,7 @@
 | 1H (annual) | 2026-03-19 | Paladin   |
 | 1H (annual) | 2026-03-19 | Smoot     |
 | 1H (annual) | 2026-03-19 | Minokawa  |
-| 2H          | 2026-07-30 | Cacti     |
+| 2H          | 2026-08-13 | Cacti     |
 | 2H          | 2026-07-30 | Fabric    |
 | 2H          | 2026-08-06 | Identus   |
 | 2H          | 2026-08-06 | Web3j     |
@@ -36,7 +36,7 @@
 | 2H          | 2026-09-03 | Lockness  |
 | 2H          | 2026-09-03 | Hiero     |
 | 2H          | 2026-09-10 | Credebl   |
-| 2H          | 2026-09-10 | ToIP      |
+| 2H          | 2026-10-29 | ToIP      |
 | 2H          | 2026-09-17 | Paladin   |
 | 2H          | 2026-09-17 | Smoot     |
 | 2H          | 2026-09-17 | Minokawa  |


### PR DESCRIPTION
## Summary

Adds the TAC meeting agenda for **6 August 2026**.

### Annual reports up for review
- Smoot Annual Review (PR #326) — Hendrik, Marcus

### Overdue
- Minokawa Annual Report — 2-week extension granted at Jul 23 meeting; due Aug 6, 2026
- Cacti Mid-Year Report — 2-week extension granted; due August 13, 2026
- Fabric Mid-Year Report — no PR submitted

### Lab updates
- DAS Interoperability Lab (PR #423) — neutral, open-source standards and pilot body for digital asset securities interoperability
- FabricOps (PR #424) — Kubernetes operator for provisioning multi-organisation Hyperledger Fabric networks

### Discussion topics
- AI contribution guidelines (PR #321)

### Configuration updates
- Extended Cacti mid-year due date from 2026-07-30 to 2026-08-13 in schedule and reminder config
- Extended ToIP mid-year due date from 2026-09-10 to 2026-10-29 in schedule and reminder config
- Updated Fabric reminder target repository from `fabric` to `fabric-x`

Also updates `mkdocs.yml` nav.
