### PR TITLE
Add meeting agenda for 13th August 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
   - Meetings:
       - meeting-minutes/index.md
       - 2026:
+          - 2026-08-13: meeting-minutes/2026/2026-08-13.md
           - 2026-08-06: meeting-minutes/2026/2026-08-06.md
           - 2026-07-30: meeting-minutes/2026/2026-07-30.md
           - 2026-07-23: meeting-minutes/2026/2026-07-23.md

--- a/tac/meeting-minutes/2026/2026-08-13.md
+++ b/tac/meeting-minutes/2026/2026-08-13.md
@@ -1,0 +1,64 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the LF Decentralized Trust Community](../images/all-are-welcome.png "All are Welcome in the LF Decentralized Trust Community")
+
+Linux Foundation Decentralized Trust is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [LF Decentralized Trust Code of Conduct](../../governing-documents/code-of-conduct.md).
+
+# Meeting Link
+- [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96405933609?password=dc76428e-6a2d-435f-a020-a590bc4b94a4)
+
+# Announcements
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [leave a comment for consideration on the upcoming newsletter wiki page](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/697270275/2026).
+- Nominations for the upcoming TAC elections will open soon. TAC members are encouraged to engage with the community, identify strong candidates, and encourage them to consider standing for election.
+
+# Annual reports
+- [Smoot Annual Review](https://github.com/LF-Decentralized-Trust/governance/pull/326) - Hendrik, Marcus
+
+# Mid-year reports
+- [Cacti Mid-Year Report](https://github.com/LF-Decentralized-Trust/governance/pull/353)
+- [Hiero Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/354)
+
+# Overdue reports
+- Minokawa Annual Report (due March 19, 2026) - extension expired August 6, 2026
+- Fabric Mid-Year Report (due July 30, 2026)
+- Identus Mid-Year Report (due August 6, 2026)
+- Web3j Mid-Year Report (due August 6, 2026)
+- Indy Mid-Year Report (due August 13, 2026)
+- AnonCreds Mid-Year Report (due August 13, 2026)
+
+# Upcoming reports
+- [2026 TAC Project Update Calendar](../../project-updates/2026/2026-schedule.md)
+- Iroha Mid-Year Report due August 20, 2026
+- Firefly Mid-Year Report due August 27, 2026
+- Besu Mid-Year Report due August 27, 2026
+
+# Labs summary
+- [DAS Interoperability Lab](https://github.com/LF-Decentralized-Trust-labs/LF-Decentralized-Trust-labs.github.io/pull/423) - neutral, open-source standards and pilot body for digital asset securities interoperability specifications and proofs-of-concept on institutional infrastructure
+- [FabricOps](https://github.com/LF-Decentralized-Trust-labs/LF-Decentralized-Trust-labs.github.io/pull/424) - Kubernetes operator for provisioning multi-organisation Hyperledger Fabric networks from declarative configuration
+
+# Discussion
+- Project report reviews.
+- Lab proposals review.
+- AI contribution guidelines — [governance PR #321](https://github.com/LF-Decentralized-Trust/governance/pull/321).
+- Open Wallet Foundation transition to LF Decentralized Trust.
+
+# Recordings
+- [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Upcoming meetings
+- [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Hendrik Ebbers
+- [ ] Kanchan Kaur
+- [ ] Kevin Millikin
+- [ ] Enrique Lacal
+- [ ] Diane Mueller
+- [ ] Venkatraman Ramakrishna
+- [ ] Osama Rabea
+- [ ] Arun S M
+- [ ] Yoav Tock
+- [ ] Matthew Whitehead

--- a/tac/meeting-minutes/2026/2026-08-13.md
+++ b/tac/meeting-minutes/2026/2026-08-13.md
@@ -39,6 +39,7 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Discussion
 - Project report reviews.
+  - [Schedule for Midyear Reviews](https://github.com/LF-Decentralized-Trust/governance/wiki/Midyear-Reviews)
 - Lab proposals review.
 - AI contribution guidelines — [governance PR #321](https://github.com/LF-Decentralized-Trust/governance/pull/321).
 - Open Wallet Foundation transition to LF Decentralized Trust.
@@ -51,14 +52,14 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Attended by
 
-- [ ] Marcus Brandenburger
-- [ ] Hendrik Ebbers
+- [x] Marcus Brandenburger
+- [x] Hendrik Ebbers
 - [ ] Kanchan Kaur
 - [ ] Kevin Millikin
 - [ ] Enrique Lacal
-- [ ] Diane Mueller
-- [ ] Venkatraman Ramakrishna
-- [ ] Osama Rabea
-- [ ] Arun S M
+- [x] Diane Mueller
+- [x] Venkatraman Ramakrishna
+- [x] Osama Rabea
+- [x] Arun S M
 - [ ] Yoav Tock
-- [ ] Matthew Whitehead
+- [x] Matthew Whitehead


### PR DESCRIPTION
## Summary

Adds the TAC meeting agenda for **13 August 2026**.

### Annual reports up for review
- Smoot (PR #326) — Hendrik, Marcus

### Mid-year reports
- Cacti (PR #353)
- Hiero (PR #354)

### Overdue
- Minokawa — extension expired August 6, 2026
- Fabric — due July 30, 2026
- Identus — due August 6, 2026
- Web3j — due August 6, 2026
- Indy — due August 13, 2026
- AnonCreds — due August 13, 2026

### Lab updates
- DAS Interoperability Lab (PR #423) — neutral, open-source standards and pilot body for digital asset securities interoperability
- FabricOps (PR #424) — Kubernetes operator for Hyperledger Fabric network provisioning

### Discussion topics
- Project report reviews
- Lab proposals review
- AI contribution guidelines (PR #321)
- Open Wallet Foundation transition to LF Decentralized Trust

Also updates `mkdocs.yml` nav.
