### PR TITLE
Add meeting agenda for 20th August 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
   - Meetings:
       - meeting-minutes/index.md
       - 2026:
+          - 2026-08-20: meeting-minutes/2026/2026-08-20.md
           - 2026-08-13: meeting-minutes/2026/2026-08-13.md
           - 2026-08-06: meeting-minutes/2026/2026-08-06.md
           - 2026-07-30: meeting-minutes/2026/2026-07-30.md

--- a/tac/meeting-minutes/2026/2026-08-20.md
+++ b/tac/meeting-minutes/2026/2026-08-20.md
@@ -9,7 +9,7 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 - [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96405933609?password=dc76428e-6a2d-435f-a020-a590bc4b94a4)
 
 # Announcements
-- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [leave a comment for consideration on the upcoming newsletter wiki page](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/697270275/2026).
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [file an issue here](https://github.com/LF-Decentralized-Trust/contribute/issues).
 - Nominations for the upcoming TAC elections will open soon. TAC members are encouraged to engage with the community, identify strong candidates, and encourage them to consider standing for election.
 
 # Annual reports
@@ -51,14 +51,14 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Attended by
 
-- [ ] Marcus Brandenburger
-- [ ] Hendrik Ebbers
-- [ ] Kanchan Kaur
-- [ ] Kevin Millikin
-- [ ] Enrique Lacal
-- [ ] Diane Mueller
-- [ ] Venkatraman Ramakrishna
-- [ ] Osama Rabea
-- [ ] Arun S M
-- [ ] Yoav Tock
-- [ ] Matthew Whitehead
+- [x] Marcus Brandenburger
+- [x] Hendrik Ebbers
+- [ ] ~~Kanchan Kaur~~
+- [ ] ~~Kevin Millikin~~
+- [ ] ~~Enrique Lacal~~
+- [x] Diane Mueller
+- [x] Venkatraman Ramakrishna
+- [ ] ~~Osama Rabea~~
+- [x] Arun S M
+- [ ] ~~Yoav Tock~~
+- [x] Matthew Whitehead

--- a/tac/meeting-minutes/2026/2026-08-20.md
+++ b/tac/meeting-minutes/2026/2026-08-20.md
@@ -1,0 +1,64 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the LF Decentralized Trust Community](../images/all-are-welcome.png "All are Welcome in the LF Decentralized Trust Community")
+
+Linux Foundation Decentralized Trust is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [LF Decentralized Trust Code of Conduct](../../governing-documents/code-of-conduct.md).
+
+# Meeting Link
+- [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96405933609?password=dc76428e-6a2d-435f-a020-a590bc4b94a4)
+
+# Announcements
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [leave a comment for consideration on the upcoming newsletter wiki page](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/697270275/2026).
+- Nominations for the upcoming TAC elections will open soon. TAC members are encouraged to engage with the community, identify strong candidates, and encourage them to consider standing for election.
+
+# Annual reports
+- [Smoot Annual Review](https://github.com/LF-Decentralized-Trust/governance/pull/326) - Hendrik, Marcus
+- [Indy Annual Review 2026](https://github.com/LF-Decentralized-Trust/governance/pull/296)
+
+# Mid-year reports
+- [Cacti Mid-Year Report](https://github.com/LF-Decentralized-Trust/governance/pull/353)
+- [Hiero Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/354)
+- [Iroha Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/356)
+
+# Overdue reports
+- Minokawa Annual Report (due March 19, 2026) - extension expired August 6, 2026
+- Fabric Mid-Year Report (due July 30, 2026)
+- Identus Mid-Year Report (due August 6, 2026)
+- Web3j Mid-Year Report (due August 6, 2026)
+- Indy Mid-Year Report (due August 13, 2026)
+- AnonCreds Mid-Year Report (due August 13, 2026)
+
+# Upcoming reports
+- [2026 TAC Project Update Calendar](../../project-updates/2026/2026-schedule.md)
+- Firefly Mid-Year Report due August 27, 2026
+- Besu Mid-Year Report due August 27, 2026
+
+# Labs summary
+- None
+
+# Discussion
+- Project report reviews.
+- Proposed new form for lab proposals — [template](https://github.com/ryjones/lab-proposal/issues/new?template=lab-proposal.yml).
+- EU Cyber Resilience Act — [presentation](https://drive.google.com/file/d/1k5YsPIiJJxxk4jUScGoli3aAPObOMvEE/view) and [online training](https://training.linuxfoundation.org/express-learning/understanding-the-eu-cyber-resilience-act-cra-lfel1001/).
+- AI contribution guidelines — [governance PR #321](https://github.com/LF-Decentralized-Trust/governance/pull/321).
+
+# Recordings
+- [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Upcoming meetings
+- [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Hendrik Ebbers
+- [ ] Kanchan Kaur
+- [ ] Kevin Millikin
+- [ ] Enrique Lacal
+- [ ] Diane Mueller
+- [ ] Venkatraman Ramakrishna
+- [ ] Osama Rabea
+- [ ] Arun S M
+- [ ] Yoav Tock
+- [ ] Matthew Whitehead


### PR DESCRIPTION
## Summary

Adds the TAC meeting agenda for **20 August 2026**.

### Annual reports up for review
- Smoot Annual Review (PR #326) — Hendrik, Marcus
- Indy Annual Review 2026 (PR #296)

### Mid-year reports up for review
- Cacti Mid-Year Report (PR #353)
- Hiero Mid-Year Review (PR #354)
- Iroha Mid-Year Review (PR #356)

### Overdue
- Minokawa Annual Report — extension expired August 6, 2026
- Fabric Mid-Year Report — due July 30, 2026
- Identus Mid-Year Report — due August 6, 2026
- Web3j Mid-Year Report — due August 6, 2026
- Indy Mid-Year Report — due August 13, 2026
- AnonCreds Mid-Year Report — due August 13, 2026

### Lab updates
- DAS Interoperability Lab (PR #423) — merged
- FabricOps (PR #424) — merged

### Discussion topics
- [Proposed new form for lab proposals](https://github.com/ryjones/lab-proposal/issues)
- EU Cyber Resilience Act
- AI contribution guidelines (PR #321)

Also updates `mkdocs.yml` nav.
