### PR TITLE
Add lab-stewards team and lab-proposals configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -30,6 +30,22 @@ teams:
       - davidwboswell
       - hartm
       - jwagantall
+  - name: lab-stewards
+    maintainers:
+      - mbrandenburger
+    members:
+      - EnriqueL8
+      - OsamaRab3
+      - VRamakrishna
+      - alvaropicazo
+      - arsulegai
+      - dmueller2001
+      - hendrikebbers
+      - kkaur01
+      - kmillikin
+      - matthew1001
+      - tock-ibm
+      - vipinsun
   - name: security-managers
     maintainers:
       - hartm
@@ -63,6 +79,13 @@ repositories:
   - name: maintainer-days
     teams:
       community: maintain
+      tac: maintain
+    visibility: public
+  - name: lab-proposals
+    teams:
+      community: maintain
+      security-managers: read
+      lab-stewards: maintain
       tac: maintain
     visibility: public
   - name: project-proposals


### PR DESCRIPTION
Added a new team 'lab-stewards' with maintainers and members, and created 'lab-proposals' with specific team permissions.