### PR TITLE
Add meeting agenda for 27th August 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,7 @@ nav:
       - meeting-minutes/index.md
       - 2026:
           - 2026 attendance: meeting-minutes/2026/attendees.md
+          - 2026-08-27: meeting-minutes/2026/2026-08-27.md
           - 2026-08-20: meeting-minutes/2026/2026-08-20.md
           - 2026-08-13: meeting-minutes/2026/2026-08-13.md
           - 2026-08-06: meeting-minutes/2026/2026-08-06.md

--- a/tac/meeting-minutes/2026/2026-08-27.md
+++ b/tac/meeting-minutes/2026/2026-08-27.md
@@ -1,0 +1,64 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the LF Decentralized Trust Community](../images/all-are-welcome.png "All are Welcome in the LF Decentralized Trust Community")
+
+Linux Foundation Decentralized Trust is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [LF Decentralized Trust Code of Conduct](../../governing-documents/code-of-conduct.md).
+
+# Meeting Link
+- [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96405933609?password=dc76428e-6a2d-435f-a020-a590bc4b94a4)
+
+# Announcements
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [file an issue here](https://github.com/LF-Decentralized-Trust/contribute/issues).
+- Nominations for the upcoming TAC elections will open soon. See the [election timeline](https://lf-decentralized-trust.github.io/governance/member-info/election-timeline/) for more details. TAC members are encouraged to engage with the community, identify strong candidates, and encourage them to consider standing for election.
+
+# Annual reports
+- [Smoot Annual Review](https://github.com/LF-Decentralized-Trust/governance/pull/326) - Hendrik, Marcus
+
+# Mid-year reports
+- [Cacti Mid-Year Report](https://github.com/LF-Decentralized-Trust/governance/pull/353)
+- [Hiero Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/354)
+- [Iroha Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/356)
+- [Web3j Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/360)
+
+# Overdue reports
+- Minokawa Annual Report (due March 19, 2026) - extension expired August 6, 2026
+- Fabric Mid-Year Report (due July 30, 2026)
+- Identus Mid-Year Report (due August 6, 2026)
+- Indy Mid-Year Report (due August 13, 2026)
+- AnonCreds Mid-Year Report (due August 13, 2026)
+- Firefly Mid-Year Report (due August 27, 2026)
+- Besu Mid-Year Report (due August 27, 2026)
+
+# Upcoming reports
+- [2026 TAC Project Update Calendar](../../project-updates/2026/2026-schedule.md)
+- Caliper Mid-Year Report due September 3, 2026
+- Lockness Mid-Year Report due September 3, 2026
+
+# Labs summary
+- None
+
+# Discussion
+- Project report reviews.
+- EU Cyber Resilience Act — [presentation](https://drive.google.com/file/d/1k5YsPIiJJxxk4jUScGoli3aAPObOMvEE/view) and [online training](https://training.linuxfoundation.org/express-learning/understanding-the-eu-cyber-resilience-act-cra-lfel1001/).
+- AI contribution guidelines — [governance PR #321](https://github.com/LF-Decentralized-Trust/governance/pull/321).
+
+# Recordings
+- [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Upcoming meetings
+- [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Hendrik Ebbers
+- [ ] Kanchan Kaur
+- [ ] Kevin Millikin
+- [ ] Enrique Lacal
+- [ ] Diane Mueller
+- [ ] Venkatraman Ramakrishna
+- [ ] Osama Rabea
+- [ ] Arun S M
+- [ ] Yoav Tock
+- [ ] Matthew Whitehead

--- a/tac/meeting-minutes/2026/2026-08-27.md
+++ b/tac/meeting-minutes/2026/2026-08-27.md
@@ -51,14 +51,14 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Attended by
 
-- [ ] Marcus Brandenburger
-- [ ] Hendrik Ebbers
-- [ ] Kanchan Kaur
-- [ ] Kevin Millikin
-- [ ] Enrique Lacal
-- [ ] Diane Mueller
-- [ ] Venkatraman Ramakrishna
-- [ ] Osama Rabea
-- [ ] Arun S M
-- [ ] Yoav Tock
-- [ ] Matthew Whitehead
+- [x] Marcus Brandenburger
+- [x] Hendrik Ebbers
+- [ ] ~~Kanchan Kaur~~
+- [ ] ~~Kevin Millikin~~
+- [x] Enrique Lacal
+- [ ] ~~Diane Mueller~~
+- [x] Venkatraman Ramakrishna
+- [ ] ~~Osama Rabea~~
+- [x] Arun S M
+- [x] Yoav Tock
+- [x] Matthew Whitehead


### PR DESCRIPTION
## Summary

Adds the TAC meeting agenda for **27 August 2026**.

### Annual reports up for review
- Smoot (PR #326) — Hendrik, Marcus

### Mid-year reports up for review
- Cacti (PR #353)
- Hiero (PR #354)
- Iroha (PR #356)
- Web3j (PR #360)

### Overdue
- Minokawa — extension expired August 6, 2026
- Fabric — due July 30, 2026
- Identus — due August 6, 2026
- Indy mid-year — due August 13, 2026
- AnonCreds — due August 13, 2026
- Firefly — due August 27, 2026
- Besu — due August 27, 2026

### Lab updates
- None

### Discussion topics carried forward
- EU Cyber Resilience Act
- AI contribution guidelines (PR #321)

Also updates `mkdocs.yml` nav.
