### PR TITLE
Add meeting agenda for 3rd September 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,7 @@ nav:
       - meeting-minutes/index.md
       - 2026:
           - 2026 attendance: meeting-minutes/2026/attendees.md
+          - 2026-09-03: meeting-minutes/2026/2026-09-03.md
           - 2026-08-27: meeting-minutes/2026/2026-08-27.md
           - 2026-08-20: meeting-minutes/2026/2026-08-20.md
           - 2026-08-13: meeting-minutes/2026/2026-08-13.md

--- a/tac/meeting-minutes/2026/2026-09-03.md
+++ b/tac/meeting-minutes/2026/2026-09-03.md
@@ -1,0 +1,70 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the LF Decentralized Trust Community](../images/all-are-welcome.png "All are Welcome in the LF Decentralized Trust Community")
+
+Linux Foundation Decentralized Trust is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [LF Decentralized Trust Code of Conduct](../../governing-documents/code-of-conduct.md).
+
+# Meeting Link
+- [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96405933609?password=dc76428e-6a2d-435f-a020-a590bc4b94a4)
+
+# Announcements
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [file an issue here](https://github.com/LF-Decentralized-Trust/contribute/issues).
+- Nominations for the upcoming TAC elections will open soon. See the [election timeline](https://lf-decentralized-trust.github.io/governance/member-info/election-timeline/) for more details. TAC members are encouraged to engage with the community, identify strong candidates, and encourage them to consider standing for election.
+
+# Annual reports
+- [Smoot Annual Review](https://github.com/LF-Decentralized-Trust/governance/pull/326) - Hendrik, Marcus
+
+# Mid-year reports
+- [Cacti Mid-Year Report](https://github.com/LF-Decentralized-Trust/governance/pull/353)
+- [Hiero Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/354)
+- [Iroha Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/356)
+- [Web3j Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/360)
+- [Besu Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/368)
+- [Fabric Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/370)
+- [AnonCreds Mid-Year Report](https://github.com/LF-Decentralized-Trust/governance/pull/372)
+
+# Overdue reports
+- Minokawa Annual Report (due March 19, 2026) - extension expired August 6, 2026; escalation discussed at the August 27 TAC meeting, update still pending
+- Identus Mid-Year Report (due August 6, 2026)
+- Indy Mid-Year Report (due August 13, 2026)
+- Firefly Mid-Year Report (due August 27, 2026)
+- Lockness Mid-Year Report (due September 3, 2026) - extension requested, pending TAC discussion
+
+# Upcoming reports
+- [2026 TAC Project Update Calendar](../../project-updates/2026/2026-schedule.md)
+- Credebl Mid-Year Report due September 10, 2026
+
+# Labs summary
+- [Open Privacy Suite](https://github.com/LF-Decentralized-Trust/lab-proposals/issues/3) - a privacy and access-control gateway for EVM permissioned networks that enforces per-organization transaction privacy, role-based method access, and auditable selective disclosure
+- [recomputable-evidence](https://github.com/LF-Decentralized-Trust/lab-proposals/issues/2) - a neutral venue for testing whether independently authored evidence-record specifications compose without silently transferring authority between them
+
+# Discussion
+- Project report reviews.
+- Lockness Mid-Year Report extension request.
+- Lab proposals review.
+- Hiero proposes moving [CLPR-spec](https://github.com/hiero-hackers/CLPR-spec) to a lab.
+- Meeting time change proposal — [governance issue #361](https://github.com/LF-Decentralized-Trust/governance/issues/361), vote currently tied.
+- Open Wallet Foundation (OWF) project migration plan and timeline.
+- EU Cyber Resilience Act — [presentation](https://drive.google.com/file/d/1k5YsPIiJJxxk4jUScGoli3aAPObOMvEE/view) and [online training](https://training.linuxfoundation.org/express-learning/understanding-the-eu-cyber-resilience-act-cra-lfel1001/).
+- AI contribution guidelines — [governance PR #321](https://github.com/LF-Decentralized-Trust/governance/pull/321).
+
+# Recordings
+- [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Upcoming meetings
+- [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Hendrik Ebbers
+- [ ] Kanchan Kaur
+- [ ] Kevin Millikin
+- [ ] Enrique Lacal
+- [ ] Diane Mueller
+- [ ] Venkatraman Ramakrishna
+- [ ] Osama Rabea
+- [ ] Arun S M
+- [ ] Yoav Tock
+- [ ] Matthew Whitehead

--- a/tac/meeting-minutes/2026/2026-09-03.md
+++ b/tac/meeting-minutes/2026/2026-09-03.md
@@ -43,7 +43,7 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 - Project report reviews.
 - Lockness Mid-Year Report extension request.
 - Lab proposals review.
-- Hiero proposes moving [CLPR-spec](https://github.com/hiero-hackers/CLPR-spec) to a lab.
+- Hiero proposes moving [CLPR-spec](https://github.com/LF-Decentralized-Trust/project-proposals/pull/58) to a lab.
 - Meeting time change proposal — [governance issue #361](https://github.com/LF-Decentralized-Trust/governance/issues/361), vote currently tied.
 - Open Wallet Foundation (OWF) project migration plan and timeline.
 - EU Cyber Resilience Act — [presentation](https://drive.google.com/file/d/1k5YsPIiJJxxk4jUScGoli3aAPObOMvEE/view) and [online training](https://training.linuxfoundation.org/express-learning/understanding-the-eu-cyber-resilience-act-cra-lfel1001/).

--- a/tac/meeting-minutes/2026/2026-09-03.md
+++ b/tac/meeting-minutes/2026/2026-09-03.md
@@ -57,14 +57,14 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Attended by
 
-- [ ] Marcus Brandenburger
-- [ ] Hendrik Ebbers
-- [ ] Kanchan Kaur
-- [ ] Kevin Millikin
-- [ ] Enrique Lacal
-- [ ] Diane Mueller
-- [ ] Venkatraman Ramakrishna
-- [ ] Osama Rabea
-- [ ] Arun S M
-- [ ] Yoav Tock
-- [ ] Matthew Whitehead
+- [x] Marcus Brandenburger
+- [x] Hendrik Ebbers
+- [ ] ~~Kanchan Kaur~~
+- [x] Kevin Millikin
+- [x] Enrique Lacal
+- [x] Diane Mueller
+- [x] Venkatraman Ramakrishna
+- [ ] ~~Osama Rabea~~
+- [ ] ~~Arun S M~~
+- [x] Yoav Tock
+- [x] Matthew Whitehead


### PR DESCRIPTION
## Summary

Adds the TAC meeting agenda for **3 September 2026**.

### Annual reports up for review
- Smoot (PR #326) — Hendrik, Marcus

### Mid-year reports up for review
- Cacti (PR #353)
- Hiero (PR #354)
- Iroha (PR #356)
- Web3j (PR #360)
- Besu (PR #368)
- Fabric (PR #370)
- AnonCreds (PR #372)

### Overdue
- Minokawa — extension expired August 6, 2026; escalation discussed August 27, update still pending
- Identus — due August 6, 2026
- Indy — due August 13, 2026
- Firefly — due August 27, 2026
- Lockness — extension requested, pending TAC discussion

### Lab updates
- Open Privacy Suite (lab-proposals #3) — privacy and access-control gateway for EVM permissioned networks
- recomputable-evidence (lab-proposals #2) — neutral venue for testing composability of evidence-record specifications

### Discussion topics carried forward
- Lockness Mid-Year Report extension request
- Hiero proposal to move CLPR-spec to a lab
- Meeting time change proposal (governance issue #361)
- Open Wallet Foundation (OWF) project migration plan and timeline
- EU Cyber Resilience Act
- AI contribution guidelines (governance PR #321)

Also updates `mkdocs.yml` nav.
