### PR TITLE
Add meeting agenda for 10th September 2026

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
       - meeting-minutes/index.md
       - 2026:
           - 2026 attendance: meeting-minutes/2026/attendees.md
+          - 2026-09-10: meeting-minutes/2026/2026-09-10.md
           - 2026-09-03: meeting-minutes/2026/2026-09-03.md
           - 2026-08-27: meeting-minutes/2026/2026-08-27.md
           - 2026-08-20: meeting-minutes/2026/2026-08-20.md

--- a/tac/meeting-minutes/2026/2026-09-10.md
+++ b/tac/meeting-minutes/2026/2026-09-10.md
@@ -62,14 +62,14 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 
 # Attended by
 
-- [ ] Marcus Brandenburger
-- [ ] Hendrik Ebbers
-- [ ] Kanchan Kaur
-- [ ] Kevin Millikin
-- [ ] Enrique Lacal
-- [ ] Diane Mueller
-- [ ] Venkatraman Ramakrishna
-- [ ] Osama Rabea
-- [ ] Arun S M
-- [ ] Yoav Tock
-- [ ] Matthew Whitehead
+- [ ] ~~Marcus Brandenburger~~
+- [x] Hendrik Ebbers
+- [ ] ~~Kanchan Kaur~~
+- [x] Kevin Millikin
+- [x] Enrique Lacal
+- [x] Diane Mueller
+- [x] Venkatraman Ramakrishna
+- [ ] ~~Osama Rabea~~
+- [x] Arun S M
+- [x] Yoav Tock
+- [ ] ~~Matthew Whitehead~~

--- a/tac/meeting-minutes/2026/2026-09-10.md
+++ b/tac/meeting-minutes/2026/2026-09-10.md
@@ -11,6 +11,7 @@ Linux Foundation Decentralized Trust is committed to creating a safe and welcomi
 # Announcements
 - The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [file an issue here](https://github.com/LF-Decentralized-Trust/contribute/issues).
 - Nominations for the upcoming TAC elections will open soon. See the [election timeline](https://lf-decentralized-trust.github.io/governance/member-info/election-timeline/) for more details. TAC members are encouraged to engage with the community, identify strong candidates, and encourage them to consider standing for election.
+- The [LFDT AI Working Group kickoff](https://www.meetup.com/lfdt-sf/events/316485550/), "AI × Decentralized Trust", is on October 6, 2026 at 9:00 AM Pacific. The session will set the group's initial scope, meeting cadence, and first work streams. Open to everyone.
 
 # Annual reports
 - [Smoot Annual Review](https://github.com/LF-Decentralized-Trust/governance/pull/326) - Hendrik, Marcus

--- a/tac/meeting-minutes/2026/2026-09-10.md
+++ b/tac/meeting-minutes/2026/2026-09-10.md
@@ -1,0 +1,74 @@
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+![Antitrust Policy Notice](../images/antitrust-policy-notice.png "Antitrust Policy Notice")
+![All are Welcome in the LF Decentralized Trust Community](../images/all-are-welcome.png "All are Welcome in the LF Decentralized Trust Community")
+
+Linux Foundation Decentralized Trust is committed to creating a safe and welcoming community for all. For more information please visit our Code of Conduct: [LF Decentralized Trust Code of Conduct](../../governing-documents/code-of-conduct.md).
+
+# Meeting Link
+- [Join us on Zoom](https://zoom-lfx.platform.linuxfoundation.org/meeting/96405933609?password=dc76428e-6a2d-435f-a020-a590bc4b94a4)
+
+# Announcements
+- The [LF Decentralized Trust /dev/weekly developer newsletter](https://lf-hyperledger.atlassian.net/wiki/spaces/DR/pages/17170445/dev+weekly+Newsletter) goes out each Friday to hundreds of LF Decentralized Trust developers. It is a collaborative effort. If you have a project release, pull request, community event, and/or relevant article you would like highlighted next week, please [file an issue here](https://github.com/LF-Decentralized-Trust/contribute/issues).
+- Nominations for the upcoming TAC elections will open soon. See the [election timeline](https://lf-decentralized-trust.github.io/governance/member-info/election-timeline/) for more details. TAC members are encouraged to engage with the community, identify strong candidates, and encourage them to consider standing for election.
+
+# Annual reports
+- [Smoot Annual Review](https://github.com/LF-Decentralized-Trust/governance/pull/326) - Hendrik, Marcus
+- [Minokawa Annual Report](https://github.com/LF-Decentralized-Trust/governance/pull/378) - Osama, Marcus
+
+# Mid-year reports
+- [Cacti Mid-Year Report](https://github.com/LF-Decentralized-Trust/governance/pull/353)
+- [Hiero Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/354)
+- [Iroha Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/356)
+- [Web3j Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/360)
+- [Besu Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/368)
+- [Fabric Mid-Year Review](https://github.com/LF-Decentralized-Trust/governance/pull/370)
+- [AnonCreds Mid-Year Report](https://github.com/LF-Decentralized-Trust/governance/pull/372)
+- [FireFly Mid-Year Report](https://github.com/LF-Decentralized-Trust/governance/pull/377)
+
+# Overdue reports
+- Identus Mid-Year Report (due August 6, 2026)
+- Indy Mid-Year Report (due August 13, 2026)
+- Lockness Mid-Year Report (due September 3, 2026) - extension requested, pending TAC discussion
+- Credebl Mid-Year Report (due September 10, 2026)
+
+# Upcoming reports
+- [2026 TAC Project Update Calendar](../../project-updates/2026/2026-schedule.md)
+- Paladin Mid-Year Report due September 17, 2026
+- Smoot Mid-Year Report due September 17, 2026
+
+# Labs summary
+- [Open Privacy Suite](https://github.com/LF-Decentralized-Trust/lab-proposals/issues/3) - a privacy and access-control gateway for EVM permissioned networks that enforces per-organization transaction privacy, role-based method access, and auditable selective disclosure
+- [recomputable-evidence](https://github.com/LF-Decentralized-Trust/lab-proposals/issues/2) - a neutral venue for testing whether independently authored evidence-record specifications compose without silently transferring authority between them
+- [CLPR](https://github.com/LF-Decentralized-Trust/lab-proposals/issues/5) - an extensible cross-ledger protocol for reliable, asynchronous, in-order message passing between independent ledger networks without bridges or intermediary validators, donated by the Hedera Governing Council and initially integrated with Hiero
+- [Blockchain Decentralisation Index](https://github.com/LF-Decentralized-Trust/lab-proposals/issues/4) - an open source toolkit for measuring the decentralisation of distributed ledgers layer by layer (consensus, tokenomics, network, software), grown out of the Edinburgh Decentralisation Index research project
+
+# Discussion
+- Project report reviews.
+- Smoot Annual Report - Weijia (Smoot maintainer) joining to discuss the project and any pending annual report items.
+- Lab proposals review.
+- Lab proposal review process update - proposals are now reviewed as GitHub issues in the lab-proposals repo instead of pull requests.
+- Meeting time change proposal — [governance issue #361](https://github.com/LF-Decentralized-Trust/governance/issues/361), vote currently tied.
+- Open Wallet Foundation (OWF) project migration plan and timeline.
+- EU Cyber Resilience Act — [presentation](https://drive.google.com/file/d/1k5YsPIiJJxxk4jUScGoli3aAPObOMvEE/view) and [online training](https://training.linuxfoundation.org/express-learning/understanding-the-eu-cyber-resilience-act-cra-lfel1001/).
+- AI contribution guidelines — [governance PR #321](https://github.com/LF-Decentralized-Trust/governance/pull/321); dedicated AI working group meetup planned for October 6.
+
+# Recordings
+- [Recordings are available on the LF Decentralized Trust calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Upcoming meetings
+- [Please check the calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/lf-decentralized-trust)
+
+# Attended by
+
+- [ ] Marcus Brandenburger
+- [ ] Hendrik Ebbers
+- [ ] Kanchan Kaur
+- [ ] Kevin Millikin
+- [ ] Enrique Lacal
+- [ ] Diane Mueller
+- [ ] Venkatraman Ramakrishna
+- [ ] Osama Rabea
+- [ ] Arun S M
+- [ ] Yoav Tock
+- [ ] Matthew Whitehead


### PR DESCRIPTION
## Summary

Adds the TAC meeting agenda for **10 September 2026**.

### Annual reports up for review
- Smoot Annual Review (PR #326) — Hendrik, Marcus
- Minokawa Annual Report (PR #378) — Osama, Marcus

### Overdue
- Identus Mid-Year Report (due August 6, 2026)
- Indy Mid-Year Report (due August 13, 2026)
- Lockness Mid-Year Report (due September 3, 2026) — extension requested, pending TAC discussion
- Credebl Mid-Year Report (due September 10, 2026)

### Lab updates
- CLPR (lab-proposals issue #5) — new proposal, cross-ledger protocol donated by the Hedera Governing Council
- Blockchain Decentralisation Index (lab-proposals issue #4) — new proposal, decentralisation measurement toolkit
- Open Privacy Suite (lab-proposals issue #3)
- recomputable-evidence (lab-proposals issue #2)

### Discussion topics carried forward
- Project report reviews
- Smoot Annual Report — Weijia (Smoot maintainer) joining to discuss the project
- Lab proposals review, including the new issue-based review process
- Meeting time change proposal (governance issue #361)
- Open Wallet Foundation (OWF) project migration plan and timeline
- EU Cyber Resilience Act
- AI contribution guidelines (governance PR #321)

Also updates `mkdocs.yml` nav.
