### PR TITLE
Send report reminders with actions/github-script

### DIFF
--- a/.github/workflows/report-reminders.yml
+++ b/.github/workflows/report-reminders.yml
@@ -3,16 +3,33 @@ on:
   schedule:
     - cron: '0 1 * * *'
   workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Log the reminders that are due without creating issues'
+        required: false
+        type: boolean
+        default: false
 permissions:
-  issues: write
+  contents: read
 jobs:
   remind:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the governance repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Convert the reminder schedule to JSON
+        run: yq -o=json '.' .github/configs/project-report-reminders.yml > "$RUNNER_TEMP/project-report-reminders.json"
       - name: Send due report reminders
-        uses: hyperledger-tooling/github-issue-schedule@c11fdda5658aea8719f9ccb9bdc94763786822e7 # 1.4
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GITHUB_TOKEN: "${{ secrets.UPDATE_REMINDERS }}"
-          CONFIG_FILE: ./.github/configs/project-report-reminders.yml
+          DRY_RUN: ${{ inputs.dry-run }}
+        with:
+          github-token: ${{ secrets.UPDATE_REMINDERS }}
+          script: |
+            const remind = require('./scripts/report-reminders.js');
+            await remind({
+              github,
+              core,
+              configFile: `${process.env.RUNNER_TEMP}/project-report-reminders.json`,
+              dryRun: process.env.DRY_RUN === 'true',
+            });

--- a/scripts/report-reminders.js
+++ b/scripts/report-reminders.js
@@ -1,0 +1,80 @@
+// Create the project report reminder issues that fall due today.
+//
+// Runs under actions/github-script from
+// .github/workflows/report-reminders.yml. The schedule is
+// .github/configs/project-report-reminders.yml, converted to JSON by
+// the workflow before this script reads it.
+//
+// A schedule is due when the number of whole days from now until
+// midnight UTC of its date, truncated toward zero, equals
+// buffer_window_days. This is the arithmetic of the
+// github-issue-schedule Go action the workflow used before, kept so
+// the switch neither skips nor repeats a reminder: a run at 01:00 UTC
+// with a seven day window picks up dates eight calendar days ahead.
+
+const fs = require('fs');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function readConfig(configFile) {
+  const config = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+  const window = Number(config.buffer_window_days);
+  if (!Number.isInteger(window) || window < 0 || window > 100000) {
+    throw new Error(`buffer_window_days must be an integer between 0 and 100000, got ${config.buffer_window_days}`);
+  }
+  if (!Array.isArray(config.projects)) {
+    throw new Error('projects must be a list');
+  }
+  return { window, projects: config.projects };
+}
+
+function dueSchedules(config, now) {
+  const due = [];
+  for (const project of config.projects) {
+    for (const schedule of project.schedules || []) {
+      const requested = Date.parse(`${schedule.date}T00:00:00Z`);
+      if (Number.isNaN(requested)) {
+        throw new Error(`invalid date "${schedule.date}" in the schedule for ${project.name}`);
+      }
+      const days = Math.trunc((requested - now.getTime()) / DAY_MS);
+      if (days === config.window) {
+        due.push({ project, schedule });
+      }
+    }
+  }
+  return due;
+}
+
+module.exports = async ({ github, core, configFile, dryRun = false, now = new Date() }) => {
+  const config = readConfig(configFile);
+  const due = dueSchedules(config, now);
+  core.info(`${now.toISOString()}: ${due.length} reminder(s) due with a ${config.window} day window`);
+
+  const failures = [];
+  for (const { project, schedule } of due) {
+    const target = `${project.github_org}/${project.github_repo}`;
+    if (dryRun) {
+      core.info(`dry run: would create "${schedule.title}" in ${target} for ${schedule.date}`);
+      continue;
+    }
+    try {
+      const { data: issue } = await github.rest.issues.create({
+        owner: project.github_org,
+        repo: project.github_repo,
+        title: schedule.title,
+        body: schedule.description,
+        assignees: project.maintainers || [],
+      });
+      core.info(`created ${issue.html_url} for ${project.name} (${schedule.date})`);
+    } catch (error) {
+      core.error(`could not create "${schedule.title}" in ${target}: ${error.message}`);
+      failures.push(target);
+    }
+  }
+  if (failures.length > 0) {
+    core.setFailed(`could not create ${failures.length} reminder(s): ${failures.join(', ')}`);
+  }
+};
+
+module.exports.dueSchedules = dueSchedules;
+module.exports.readConfig = readConfig;


### PR DESCRIPTION
The report-reminders workflow used the hyperledger-tooling github-issue-schedule Docker action, which rebuilds its image on every run from golang:1.20.4-bullseye. Debian bullseye is end of life and the bullseye-security Release file expired on 2026-09-07, so apt update fails and the workflow has failed since the 2026-09-08 run.

Replace the action with scripts/report-reminders.js run under actions/github-script. The workflow converts the YAML schedule to JSON with the runner's yq, and the script creates the due issues with the UPDATE_REMINDERS token. The whole-day arithmetic of the Go action is kept (truncate toward zero, compare with buffer_window_days) so the switch neither skips nor repeats a reminder. A dry-run input on workflow_dispatch logs what would be created without creating it.

Assisted-by: anthropic:claude-fable-5-1